### PR TITLE
fix: throw exception when cell is passed into another cell

### DIFF
--- a/src/Common/Entity/Cell.php
+++ b/src/Common/Entity/Cell.php
@@ -41,7 +41,7 @@ abstract class Cell
     final public static function fromValue(mixed $value, ?Style $style = null): self
     {
         if ($value instanceof self) {
-            throw new InvalidArgumentException('Cannot pass another Cell as a value.');
+            throw new InvalidArgumentException(sprintf('Cannot pass an instance of %s a value.', self::class));
         }
 
         if (\is_bool($value)) {

--- a/src/Common/Entity/Cell.php
+++ b/src/Common/Entity/Cell.php
@@ -41,7 +41,7 @@ abstract class Cell
     final public static function fromValue(mixed $value, ?Style $style = null): self
     {
         if ($value instanceof self) {
-            throw new InvalidArgumentException(sprintf('Cannot pass an instance of %s a value.', self::class));
+            throw new InvalidArgumentException(sprintf('Cannot pass an instance of %s as a value.', self::class));
         }
 
         if (\is_bool($value)) {

--- a/src/Common/Entity/Cell.php
+++ b/src/Common/Entity/Cell.php
@@ -15,6 +15,7 @@ use OpenSpout\Common\Entity\Cell\FormulaCell;
 use OpenSpout\Common\Entity\Cell\NumericCell;
 use OpenSpout\Common\Entity\Cell\StringCell;
 use OpenSpout\Common\Entity\Style\Style;
+use OpenSpout\Common\Exception\InvalidArgumentException;
 
 abstract class Cell
 {
@@ -39,6 +40,10 @@ abstract class Cell
 
     final public static function fromValue(mixed $value, ?Style $style = null): self
     {
+        if ($value instanceof self) {
+            throw new InvalidArgumentException('Cannot pass another Cell as a value.');
+        }
+
         if (\is_bool($value)) {
             return new BooleanCell($value, $style);
         }

--- a/tests/Common/Entity/CellTest.php
+++ b/tests/Common/Entity/CellTest.php
@@ -82,7 +82,7 @@ final class CellTest extends TestCase
     public function testPassingCellAsValueShouldThrowError(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot pass an instance of OpenSpout\Common\Entity\Cell a value.');
+        $this->expectExceptionMessage('Cannot pass an instance of OpenSpout\Common\Entity\Cell as a value.');
 
         Cell::fromValue(Cell::fromValue(''));
     }

--- a/tests/Common/Entity/CellTest.php
+++ b/tests/Common/Entity/CellTest.php
@@ -82,7 +82,7 @@ final class CellTest extends TestCase
     public function testPassingCellAsValueShouldThrowError(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot pass another Cell as a value.');
+        $this->expectExceptionMessage('Cannot pass an instance of OpenSpout\Common\Entity\Cell a value.');
 
         Cell::fromValue(Cell::fromValue(''));
     }

--- a/tests/Common/Entity/CellTest.php
+++ b/tests/Common/Entity/CellTest.php
@@ -14,6 +14,7 @@ use OpenSpout\Common\Entity\Cell\ErrorCell;
 use OpenSpout\Common\Entity\Cell\FormulaCell;
 use OpenSpout\Common\Entity\Cell\NumericCell;
 use OpenSpout\Common\Entity\Cell\StringCell;
+use OpenSpout\Common\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -76,5 +77,13 @@ final class CellTest extends TestCase
         self::assertInstanceOf(ErrorCell::class, $cell);
         self::assertNull($cell->getValue());
         self::assertSame([], $cell->getRawValue());
+    }
+
+    public function testPassingCellAsValueShouldThrowError(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot pass another Cell as a value.');
+
+        Cell::fromValue(Cell::fromValue(''));
     }
 }


### PR DESCRIPTION
Hi!

This PR is to throw a decent error when a cell is passed to another cell as a value.

I had the following in my code:
```php
$cells = [Cell::fromValue('')];
$row = Row::fromValues($cells);
```

Which lead to the stacktrace:
```
OpenSpout\Common\Exception\InvalidArgumentException : Trying to add a value with an unsupported type: NULL
 /home/www/app/vendor/openspout/openspout/src/Writer/XLSX/Manager/WorksheetManager.php:218
 /home/www/app/vendor/openspout/openspout/src/Writer/XLSX/Manager/WorksheetManager.php:134
 /home/www/app/vendor/openspout/openspout/src/Writer/XLSX/Manager/WorksheetManager.php:95
 /home/www/app/vendor/openspout/openspout/src/Writer/Common/Manager/AbstractWorkbookManager.php:260
 /home/www/app/vendor/openspout/openspout/src/Writer/Common/Manager/AbstractWorkbookManager.php:130
 /home/www/app/vendor/openspout/openspout/src/Writer/AbstractWriterMultiSheets.php:105
 /home/www/app/vendor/openspout/openspout/src/Writer/AbstractWriter.php:107
```


With this PR, it leads to the stacktrace:
```
OpenSpout\Common\Exception\InvalidArgumentException : Cannot pass an instance of OpenSpout\Common\Entity\Cell as a value.
 /home/www/app/vendor/openspout/openspout/src/Common/Entity/Cell.php:44
 /home/www/app/vendor/openspout/openspout/src/Common/Entity/Row.php:40
 /home/www/app/vendor/openspout/openspout/src/Common/Entity/Row.php:39
```

The fix was to do:
```php
$cells = [Cell::fromValue('')];
$row = new Row($cells);
```

