### PR TITLE
[XLSX] Add feature to set row height

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -56,11 +56,6 @@ parameters:
 			path: src/Writer/XLSX/Entity/SheetView.php
 
 		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'OpenSpout\\\\\\\\Common\\\\\\\\Entity\\\\\\\\Cell\\\\\\\\NumericCell' and OpenSpout\\\\Common\\\\Entity\\\\Cell\\\\NumericCell will always evaluate to true\\.$#"
-			count: 1
-			path: tests/Common/Entity/CellTest.php
-
-		-
 			message: "#^Method OpenSpout\\\\Reader\\\\CSV\\\\SpoutTestStream\\:\\:url_stat\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Reader/CSV/SpoutTestStream.php

--- a/src/Common/Entity/Row.php
+++ b/src/Common/Entity/Row.php
@@ -20,6 +20,9 @@ final class Row
     /** The row style. */
     private Style $style;
 
+    /** Row height. */
+    private string $height = '';
+
     /**
      * Row constructor.
      *
@@ -106,6 +109,24 @@ final class Row
         $this->style = $style ?? new Style();
 
         return $this;
+    }
+
+    /**
+     * Set row height.
+     */
+    public function setHeight(string $height): self
+    {
+        $this->height = $height;
+
+        return $this;
+    }
+
+    /**
+     * Returns row height.
+     */
+    public function getHeight(): string
+    {
+        return $this->height;
     }
 
     /**

--- a/src/Common/Entity/Row.php
+++ b/src/Common/Entity/Row.php
@@ -21,7 +21,7 @@ final class Row
     private Style $style;
 
     /** Row height. */
-    private string $height = '';
+    private float $height = 0;
 
     /**
      * Row constructor.
@@ -114,7 +114,7 @@ final class Row
     /**
      * Set row height.
      */
-    public function setHeight(string $height): self
+    public function setHeight(float $height): self
     {
         $this->height = $height;
 
@@ -124,7 +124,7 @@ final class Row
     /**
      * Returns row height.
      */
-    public function getHeight(): string
+    public function getHeight(): float
     {
         return $this->height;
     }

--- a/src/Writer/XLSX/Manager/WorksheetManager.php
+++ b/src/Writer/XLSX/Manager/WorksheetManager.php
@@ -124,7 +124,7 @@ final class WorksheetManager implements WorksheetManagerInterface
 
         $rowHeight = $row->getHeight();
         $hasCustomHeight = ($this->options->DEFAULT_ROW_HEIGHT > 0 || $rowHeight > 0) ? '1' : '0';
-		$rowXML = "<row r=\"{$rowIndexOneBased}\" spans=\"1:{$numCells}\" ".($rowHeight > 0 ? "ht=\"{$rowHeight}\" " : '')."customHeight=\"{$hasCustomHeight}\">";
+        $rowXML = "<row r=\"{$rowIndexOneBased}\" spans=\"1:{$numCells}\" ".($rowHeight > 0 ? "ht=\"{$rowHeight}\" " : '')."customHeight=\"{$hasCustomHeight}\">";
 
         foreach ($row->getCells() as $columnIndexZeroBased => $cell) {
             $registeredStyle = $this->applyStyleAndRegister($cell, $rowStyle);

--- a/src/Writer/XLSX/Manager/WorksheetManager.php
+++ b/src/Writer/XLSX/Manager/WorksheetManager.php
@@ -124,7 +124,7 @@ final class WorksheetManager implements WorksheetManagerInterface
 
         $rowHeight = $row->getHeight();
         $hasCustomHeight = ($this->options->DEFAULT_ROW_HEIGHT > 0 || $rowHeight > 0) ? '1' : '0';
-        $rowXML = "<row r=\"{$rowIndexOneBased}\" spans=\"1:{$numCells}\" " . ($rowHeight > 0 ? "ht=\"{$rowHeight}\" " : "") . "customHeight=\"{$hasCustomHeight}\">";
+		$rowXML = "<row r=\"{$rowIndexOneBased}\" spans=\"1:{$numCells}\" ".($rowHeight > 0 ? "ht=\"{$rowHeight}\" " : '')."customHeight=\"{$hasCustomHeight}\">";
 
         foreach ($row->getCells() as $columnIndexZeroBased => $cell) {
             $registeredStyle = $this->applyStyleAndRegister($cell, $rowStyle);

--- a/src/Writer/XLSX/Manager/WorksheetManager.php
+++ b/src/Writer/XLSX/Manager/WorksheetManager.php
@@ -122,8 +122,9 @@ final class WorksheetManager implements WorksheetManagerInterface
         $rowIndexOneBased = $worksheet->getLastWrittenRowIndex() + 1;
         $numCells = $row->getNumCells();
 
-        $hasCustomHeight = $this->options->DEFAULT_ROW_HEIGHT > 0 ? '1' : '0';
-        $rowXML = "<row r=\"{$rowIndexOneBased}\" spans=\"1:{$numCells}\" customHeight=\"{$hasCustomHeight}\">";
+        $rowHeight = $row->getHeight();
+        $hasCustomHeight = ($this->options->DEFAULT_ROW_HEIGHT > 0 || $rowHeight > 0) ? '1' : '0';
+        $rowXML = "<row r=\"{$rowIndexOneBased}\" spans=\"1:{$numCells}\" " . ($rowHeight > 0 ? "ht=\"{$rowHeight}\" " : "") . "customHeight=\"{$hasCustomHeight}\">";
 
         foreach ($row->getCells() as $columnIndexZeroBased => $cell) {
             $registeredStyle = $this->applyStyleAndRegister($cell, $rowStyle);

--- a/tests/Common/Entity/CellTest.php
+++ b/tests/Common/Entity/CellTest.php
@@ -25,7 +25,7 @@ final class CellTest extends TestCase
     {
         self::assertInstanceOf(NumericCell::class, Cell::fromValue(0));
         self::assertInstanceOf(NumericCell::class, Cell::fromValue(1));
-        self::assertInstanceOf(NumericCell::class, Cell::fromValue(10.1));
+        self::assertInstanceOf(NumericCell::class, Cell::fromValue(10.2));
         self::assertInstanceOf(NumericCell::class, Cell::fromValue(10.10000000000000000000001));
         self::assertInstanceOf(NumericCell::class, Cell::fromValue(0x539));
         self::assertInstanceOf(NumericCell::class, Cell::fromValue(02471));

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -10,6 +10,7 @@ use DOMElement;
 use finfo;
 use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Common\Entity\Row;
+use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Common\Exception\IOException;
 use OpenSpout\Reader\Wrapper\XMLReader;
 use OpenSpout\TestUsingResource;
@@ -429,6 +430,20 @@ final class WriterTest extends TestCase
         $this->writeToXLSXFile($dataRows, $fileName);
 
         $this->assertInlineDataWasWrittenToSheet($fileName, 1, 'control _x0015_ character');
+    }
+
+    public function testAddRowShouldApplyHeight(): void
+    {
+        $fileName = 'test_add_row_should_apply_height.xlsx';
+
+        $this->writeToXLSXFile([Row::fromValues(['xlsx--11'])->setHeight('25')], $fileName);
+
+        $xmlReader = $this->getXmlReaderForSheetFromXmlFile($fileName, '1');
+
+        $xmlReader->readUntilNodeFound('row');
+        $DOMNode = $xmlReader->expand();
+        self::assertEquals('25', $DOMNode->getAttribute('ht'), 'Row height does not equal given value.');
+        self::assertEquals('1', $DOMNode->getAttribute('customHeight'), 'Row does not have custom height flag set.');
     }
 
     public function testCloseShouldAddMergeCellTags(): void

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -441,6 +441,7 @@ final class WriterTest extends TestCase
 
         $xmlReader->readUntilNodeFound('row');
         $DOMNode = $xmlReader->expand();
+        self::assertInstanceOf(DOMElement::class, $DOMNode);
         self::assertEquals(25, $DOMNode->getAttribute('ht'), 'Row height does not equal given value.');
         self::assertEquals('1', $DOMNode->getAttribute('customHeight'), 'Row does not have custom height flag set.');
     }

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -436,13 +436,13 @@ final class WriterTest extends TestCase
     {
         $fileName = 'test_add_row_should_apply_height.xlsx';
 
-        $this->writeToXLSXFile([Row::fromValues(['xlsx--11'])->setHeight('25')], $fileName);
+        $this->writeToXLSXFile([Row::fromValues(['xlsx--11'])->setHeight(25)], $fileName);
 
         $xmlReader = $this->getXmlReaderForSheetFromXmlFile($fileName, '1');
 
         $xmlReader->readUntilNodeFound('row');
         $DOMNode = $xmlReader->expand();
-        self::assertEquals('25', $DOMNode->getAttribute('ht'), 'Row height does not equal given value.');
+        self::assertEquals(25, $DOMNode->getAttribute('ht'), 'Row height does not equal given value.');
         self::assertEquals('1', $DOMNode->getAttribute('customHeight'), 'Row does not have custom height flag set.');
     }
 

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -10,7 +10,6 @@ use DOMElement;
 use finfo;
 use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Common\Entity\Row;
-use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Common\Exception\IOException;
 use OpenSpout\Reader\Wrapper\XMLReader;
 use OpenSpout\TestUsingResource;


### PR DESCRIPTION
I'm trying to add support for setting row height, but I don't know how to do it.

I've re-added getter/setter and a property which were removed in a recent commit due to being unused. I've also added a failing test.

What I don't know is what the syntax in the raw XML output (XLS or ODS) would be for specifying the height of the row, or where this code would need to be.

The code would check for strlen() of the height property, and then apply the height to the row if height has been set via the setter.

I recently did a PR for celllVerticalAlignment and explicit setWrapText to false: https://github.com/openspout/openspout/pull/63

I'm trying to replicate doing something like this equivalent in XLSXWriter:

```
if ($lines > 1) { $row_options['height'] = $lines * 12.1; }
$writer->writeSheetRow('Sheet1', array_values($row), $row_options);
```

Any help or pointers would be much appreciated. I'd be happy to fully finish this PR and tests if only I knew how!