### PR TITLE
RowIteratorInterface: add `null` as a valid return type

### DIFF
--- a/src/Reader/CSV/RowIterator.php
+++ b/src/Reader/CSV/RowIterator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenSpout\Reader\CSV;
 
+use Iterator;
 use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Common\Entity\Row;
 use OpenSpout\Common\Helper\EncodingHelper;

--- a/src/Reader/CSV/RowIterator.php
+++ b/src/Reader/CSV/RowIterator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OpenSpout\Reader\CSV;
 
-use Iterator;
 use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Common\Entity\Row;
 use OpenSpout\Common\Helper\EncodingHelper;
@@ -16,7 +15,7 @@ use OpenSpout\Reader\RowIteratorInterface;
 final class RowIterator implements RowIteratorInterface
 {
     /**
-     * Value passed to fgetcsv. 0 means "unlimited" (slightly slower but accomodates for very long lines).
+     * Value passed to fgetcsv. 0 means "unlimited" (slightly slower but accommodates for very long lines).
      */
     public const MAX_READ_BYTES_PER_LINE = 0;
 

--- a/src/Reader/CSV/RowIterator.php
+++ b/src/Reader/CSV/RowIterator.php
@@ -95,7 +95,7 @@ final class RowIterator implements RowIteratorInterface
      *
      * @see http://php.net/manual/en/iterator.current.php
      */
-    public function current(): Row
+    public function current(): ?Row
     {
         return $this->rowBuffer;
     }

--- a/src/Reader/RowIteratorInterface.php
+++ b/src/Reader/RowIteratorInterface.php
@@ -8,9 +8,7 @@ use Iterator;
 use OpenSpout\Common\Entity\Row;
 
 /**
- * @extends Iterator<Row>
- *
- * @template-extends Iterator<int, null|Row>
+ * @extends Iterator<null|Row>
  */
 interface RowIteratorInterface extends Iterator
 {

--- a/src/Reader/RowIteratorInterface.php
+++ b/src/Reader/RowIteratorInterface.php
@@ -12,5 +12,5 @@ use OpenSpout\Common\Entity\Row;
  */
 interface RowIteratorInterface extends Iterator
 {
-    public function current(): Row;
+    public function current(): ?Row;
 }

--- a/src/Reader/RowIteratorInterface.php
+++ b/src/Reader/RowIteratorInterface.php
@@ -9,6 +9,8 @@ use OpenSpout\Common\Entity\Row;
 
 /**
  * @extends Iterator<Row>
+ *
+ * @template-extends Iterator<int, null|Row>
  */
 interface RowIteratorInterface extends Iterator
 {

--- a/tests/Reader/CSV/ReaderTest.php
+++ b/tests/Reader/CSV/ReaderTest.php
@@ -129,6 +129,20 @@ final class ReaderTest extends TestCase
         self::assertSame([], $allRows);
     }
 
+    public function testReadShouldReadEmptyFileUsingRowIteratorWithNullRow(): void
+    {
+        $resourcePath = TestUsingResource::getResourcePath('csv_empty.csv');
+        $reader = $this->createCSVReader(null, null);
+        $reader->open($resourcePath);
+
+        $sheet = $reader->getSheetIterator()->current();
+
+        $row = $sheet->getRowIterator();
+        $row->rewind();
+
+        self::assertNull($row->current());
+    }
+
     public function testReadShouldHaveTheRightNumberOfCells(): void
     {
         $allRows = $this->getAllRowsForFile('csv_with_different_cells_number.csv');


### PR DESCRIPTION
The row buffer can can be null per
`
    /** @var null|Row Buffer used to store the current row, while checking if there are more rows to read */
    private ?Row $rowBuffer;
`

Updated the functions to allow returning null.