### PR TITLE
Add PHP 8.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
           - "ubuntu-latest"
         php-version:
           - "8.0"
+          - "8.2"
         code-coverage:
           - "none"
         include:

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     ],
     "homepage": "https://github.com/openspout/openspout",
     "require": {
-        "php": "~8.0.0 || ~8.1.0",
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
         "ext-dom": "*",
         "ext-fileinfo": "*",
         "ext-filter": "*",

--- a/src/Reader/XLSX/Helper/CellValueFormatter.php
+++ b/src/Reader/XLSX/Helper/CellValueFormatter.php
@@ -242,14 +242,24 @@ final class CellValueFormatter
         $baseDate = $this->shouldUse1904Dates ? '1904-01-01' : '1899-12-30';
 
         $daysSinceBaseDate = (int) $nodeValue;
+        $daysSign = '+';
+        if ($daysSinceBaseDate < 0) {
+            $daysSinceBaseDate = abs($daysSinceBaseDate);
+            $daysSign = '-';
+        }
         $timeRemainder = fmod($nodeValue, 1);
         $secondsRemainder = round($timeRemainder * self::NUM_SECONDS_IN_ONE_DAY, 0);
+        $secondsSign = '+';
+        if ($secondsRemainder < 0) {
+            $secondsRemainder = abs($secondsRemainder);
+            $secondsSign = '-';
+        }
 
         $dateObj = DateTimeImmutable::createFromFormat('|Y-m-d', $baseDate);
         \assert(false !== $dateObj);
-        $dateObj = $dateObj->modify('+'.$daysSinceBaseDate.'days');
+        $dateObj = $dateObj->modify($daysSign.$daysSinceBaseDate.'days');
         \assert(false !== $dateObj);
-        $dateObj = $dateObj->modify('+'.$secondsRemainder.'seconds');
+        $dateObj = $dateObj->modify($secondsSign.$secondsRemainder.'seconds');
         \assert(false !== $dateObj);
 
         if ($this->shouldFormatDates) {

--- a/src/Writer/ODS/Helper/FileSystemHelper.php
+++ b/src/Writer/ODS/Helper/FileSystemHelper.php
@@ -117,12 +117,20 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
 
         $contentXmlFileContents .= '<office:body><office:spreadsheet>';
 
-        $this->createFileWithContents($this->rootFolder, self::CONTENT_XML_FILE_NAME, $contentXmlFileContents);
+        $topContentTempFile = uniqid(self::CONTENT_XML_FILE_NAME);
+        $this->createFileWithContents($this->rootFolder, $topContentTempFile, $contentXmlFileContents);
 
         // Append sheets content to "content.xml"
         $contentXmlFilePath = $this->rootFolder.\DIRECTORY_SEPARATOR.self::CONTENT_XML_FILE_NAME;
-        $contentXmlHandle = fopen($contentXmlFilePath, 'a');
+        $contentXmlHandle = fopen($contentXmlFilePath, 'w');
         \assert(false !== $contentXmlHandle);
+
+        $topContentTempPathname = $this->rootFolder.\DIRECTORY_SEPARATOR.$topContentTempFile;
+        $topContentTempHandle = fopen($topContentTempPathname, 'r');
+        \assert(false !== $topContentTempHandle);
+        stream_copy_to_stream($topContentTempHandle, $contentXmlHandle);
+        fclose($topContentTempHandle);
+        unlink($topContentTempPathname);
 
         foreach ($worksheets as $worksheet) {
             // write the "<table:table>" node, with the final sheet's name

--- a/tests/Reader/CSV/SpoutTestStream.php
+++ b/tests/Reader/CSV/SpoutTestStream.php
@@ -10,6 +10,8 @@ namespace OpenSpout\Reader\CSV;
  */
 final class SpoutTestStream
 {
+    public $context;
+
     public const CLASS_NAME = __CLASS__;
 
     public const PATH_TO_CSV_RESOURCES = 'tests/resources/csv/';

--- a/tests/Reader/CSV/SpoutTestStream.php
+++ b/tests/Reader/CSV/SpoutTestStream.php
@@ -10,12 +10,13 @@ namespace OpenSpout\Reader\CSV;
  */
 final class SpoutTestStream
 {
-    public $context;
-
     public const CLASS_NAME = __CLASS__;
 
     public const PATH_TO_CSV_RESOURCES = 'tests/resources/csv/';
     public const CSV_EXTENSION = '.csv';
+
+    /** @var null|resource */
+    public $context;
 
     private int $position;
 


### PR DESCRIPTION
Allow php 8.2 and add it to the test matrix. This PR fixes also a deprecation in the custom stream wrapper.

I'm not sure what causes the other failing tests as I can't reproduce them on my local php 8.2 installation 🤔 