### PR TITLE
add isEmpty function to Cell

### DIFF
--- a/src/Common/Entity/Cell.php
+++ b/src/Common/Entity/Cell.php
@@ -24,6 +24,8 @@ abstract class Cell
         $this->setStyle($style);
     }
 
+    abstract public function isEmpty(): bool;
+
     abstract public function getValue(): null|bool|string|int|float|DateTimeInterface|DateInterval;
 
     final public function setStyle(?Style $style): void

--- a/src/Common/Entity/Cell/BooleanCell.php
+++ b/src/Common/Entity/Cell/BooleanCell.php
@@ -21,4 +21,9 @@ final class BooleanCell extends Cell
     {
         return $this->value;
     }
+
+    public function isEmpty(): bool
+    {
+        return false;
+    }
 }

--- a/src/Common/Entity/Cell/DateIntervalCell.php
+++ b/src/Common/Entity/Cell/DateIntervalCell.php
@@ -22,4 +22,9 @@ final class DateIntervalCell extends Cell
     {
         return $this->value;
     }
+
+    public function isEmpty(): bool
+    {
+        return false;
+    }
 }

--- a/src/Common/Entity/Cell/DateTimeCell.php
+++ b/src/Common/Entity/Cell/DateTimeCell.php
@@ -22,4 +22,9 @@ final class DateTimeCell extends Cell
     {
         return $this->value;
     }
+
+    public function isEmpty(): bool
+    {
+        return false;
+    }
 }

--- a/src/Common/Entity/Cell/EmptyCell.php
+++ b/src/Common/Entity/Cell/EmptyCell.php
@@ -21,4 +21,9 @@ final class EmptyCell extends Cell
     {
         return $this->value;
     }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->value);
+    }
 }

--- a/src/Common/Entity/Cell/ErrorCell.php
+++ b/src/Common/Entity/Cell/ErrorCell.php
@@ -26,4 +26,9 @@ final class ErrorCell extends Cell
     {
         return $this->value;
     }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->value);
+    }
 }

--- a/src/Common/Entity/Cell/FormulaCell.php
+++ b/src/Common/Entity/Cell/FormulaCell.php
@@ -21,4 +21,9 @@ final class FormulaCell extends Cell
     {
         return $this->value;
     }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->value);
+    }
 }

--- a/src/Common/Entity/Cell/NumericCell.php
+++ b/src/Common/Entity/Cell/NumericCell.php
@@ -21,4 +21,9 @@ final class NumericCell extends Cell
     {
         return $this->value;
     }
+
+    public function isEmpty(): bool
+    {
+        return false;
+    }
 }

--- a/src/Common/Entity/Cell/StringCell.php
+++ b/src/Common/Entity/Cell/StringCell.php
@@ -21,4 +21,9 @@ final class StringCell extends Cell
     {
         return $this->value;
     }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->value);
+    }
 }


### PR DESCRIPTION
in box\spout, there is a `isEmpty` function which is very convenient, but in openspout, the only way to test if a cell is empty is to use `instanceof EmptyCell`, but in order to test if is not I have to write `!($cell instanceof EmptyCell)` which is not a straight forward.

So I created this `isEmpty` function, to test if a cell is null or an empty string.

I don't know if using the `empty` function on EmptyCell is  appropriate. Please let me know if it's not.

anyway, thanks for this package.