### PR TITLE
Set the SheetIterator index to zero on construct

### DIFF
--- a/src/Reader/XLSX/SheetIterator.php
+++ b/src/Reader/XLSX/SheetIterator.php
@@ -17,7 +17,7 @@ final class SheetIterator implements SheetIteratorInterface
     private array $sheets;
 
     /** @var int The index of the sheet being read (zero-based) */
-    private int $currentSheetIndex;
+    private int $currentSheetIndex = 0;
 
     /**
      * @param SheetManager $sheetManager Manages sheets

--- a/tests/Reader/XLSX/SheetTest.php
+++ b/tests/Reader/XLSX/SheetTest.php
@@ -34,6 +34,19 @@ final class SheetTest extends TestCase
         self::assertTrue($sheets[1]->isVisible());
     }
 
+    public function testReaderSheetIteratorKeyMethodShouldReturnFirstKey(): void
+    {
+        $resourcePath = TestUsingResource::getResourcePath('two_sheets_with_custom_names_and_custom_active_tab.xlsx');
+        $options = new Options();
+        $options->setTempFolder((new TestUsingResource())->getTempFolderPath());
+        $reader = new Reader($options);
+        $reader->open($resourcePath);
+
+        self::assertSame(1, $reader->getSheetIterator()->key());
+
+        $reader->close();
+    }
+
     /**
      * @return Sheet[]
      */


### PR DESCRIPTION
Because of the usage of type properties the `$currentSheetIndex` property must be set to zero by default.

Otherwise the following exception will be raised when calling the `current` method. `"Typed property OpenSpout\\Reader\\XLSX\\SheetIterator::$currentSheetIndex must not be accessed before initialization"`