### PR TITLE
fix "Undefined array key 1"

### DIFF
--- a/src/Reader/XLSX/RowIterator.php
+++ b/src/Reader/XLSX/RowIterator.php
@@ -297,7 +297,7 @@ final class RowIterator implements RowIteratorInterface
         // Read spans info if present
         $numberOfColumnsForRow = $this->numColumns;
         $spans = $xmlReader->getAttribute(self::XML_ATTRIBUTE_SPANS); // returns '1:5' for instance
-        if (null !== $spans) {
+        if ($spans) {
             [, $numberOfColumnsForRow] = explode(':', $spans);
             $numberOfColumnsForRow = (int) $numberOfColumnsForRow;
         }


### PR DESCRIPTION
Some xlsx files will get the empty string $spans to trigger this error, change back to the 3.x version of the judgment method can improve compatibility.

https://github.com/openspout/openspout/blob/dfbbd53b5edcd486b45a37f6a04fac33073c70f3/src/Reader/XLSX/RowIterator.php#L310-L314