### PR TITLE
fix "Undefined array key 1"

### DIFF
--- a/src/Reader/XLSX/RowIterator.php
+++ b/src/Reader/XLSX/RowIterator.php
@@ -297,7 +297,7 @@ final class RowIterator implements RowIteratorInterface
         // Read spans info if present
         $numberOfColumnsForRow = $this->numColumns;
         $spans = $xmlReader->getAttribute(self::XML_ATTRIBUTE_SPANS); // returns '1:5' for instance
-        if (null !== $spans) {
+        if (null !== $spans && '' !== $spans) {
             [, $numberOfColumnsForRow] = explode(':', $spans);
             $numberOfColumnsForRow = (int) $numberOfColumnsForRow;
         }


### PR DESCRIPTION
Some xlsx files will get the empty string $spans to raise this error, add the empty string judgment to improve compatibility.