### PR TITLE
XLSX: Use platform appropriate directory separator for shared strings temp filename

### DIFF
--- a/src/Reader/XLSX/Manager/SharedStringsCaching/FileBasedStrategy.php
+++ b/src/Reader/XLSX/Manager/SharedStringsCaching/FileBasedStrategy.php
@@ -164,7 +164,7 @@ final class FileBasedStrategy implements CachingStrategyInterface
     {
         $numTempFile = (int) ($sharedStringIndex / $this->maxNumStringsPerTempFile);
 
-        return $this->tempFolder.'/sharedstrings'.$numTempFile;
+        return $this->tempFolder.\DIRECTORY_SEPARATOR.'sharedstrings'.$numTempFile;
     }
 
     /**


### PR DESCRIPTION
fixes #155