### PR TITLE
Add PHP 8.2 support to 3.x branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         php-version:
           - "8.1"
+          - "8.2"
 
     steps:
       - name: "Checkout"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     ],
     "homepage": "https://github.com/openspout/openspout",
     "require": {
-        "php": "~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0",
+        "php": "~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0",
         "ext-dom": "*",
         "ext-filter": "*",
         "ext-libxml": "*",

--- a/src/Reader/XLSX/Helper/CellValueFormatter.php
+++ b/src/Reader/XLSX/Helper/CellValueFormatter.php
@@ -260,12 +260,23 @@ class CellValueFormatter
         $baseDate = $this->shouldUse1904Dates ? '1904-01-01' : '1899-12-30';
 
         $daysSinceBaseDate = (int) $nodeValue;
+        $daysSign = '+';
+        if ($daysSinceBaseDate < 0) {
+            $daysSinceBaseDate = abs($daysSinceBaseDate);
+            $daysSign = '-';
+        }
+
         $timeRemainder = fmod($nodeValue, 1);
         $secondsRemainder = round($timeRemainder * self::NUM_SECONDS_IN_ONE_DAY, 0);
+        $secondsSign = '+';
+        if ($secondsRemainder < 0) {
+            $secondsRemainder = abs($secondsRemainder);
+            $secondsSign = '-';
+        }
 
         $dateObj = \DateTime::createFromFormat('|Y-m-d', $baseDate);
-        $dateObj->modify('+'.$daysSinceBaseDate.'days');
-        $dateObj->modify('+'.$secondsRemainder.'seconds');
+        $dateObj = $dateObj->modify($daysSign.$daysSinceBaseDate.'days');
+        $dateObj = $dateObj->modify($secondsSign.$secondsRemainder.'seconds');
 
         if ($this->shouldFormatDates) {
             $styleNumberFormatCode = $this->styleManager->getNumberFormatCode($cellStyleId);

--- a/src/Writer/ODS/Helper/FileSystemHelper.php
+++ b/src/Writer/ODS/Helper/FileSystemHelper.php
@@ -101,11 +101,19 @@ class FileSystemHelper extends \OpenSpout\Common\Helper\FileSystemHelper impleme
 
         $contentXmlFileContents .= '<office:body><office:spreadsheet>';
 
-        $this->createFileWithContents($this->rootFolder, self::CONTENT_XML_FILE_NAME, $contentXmlFileContents);
+        $topContentTempFile = uniqid(self::CONTENT_XML_FILE_NAME);
+        $this->createFileWithContents($this->rootFolder, $topContentTempFile, $contentXmlFileContents);
 
         // Append sheets content to "content.xml"
         $contentXmlFilePath = $this->rootFolder.'/'.self::CONTENT_XML_FILE_NAME;
-        $contentXmlHandle = fopen($contentXmlFilePath, 'a');
+        $contentXmlHandle = fopen($contentXmlFilePath, 'w');
+
+        $topContentTempPathname = $this->rootFolder.\DIRECTORY_SEPARATOR.$topContentTempFile;
+        $topContentTempHandle = fopen($topContentTempPathname, 'r');
+        \assert(false !== $topContentTempHandle);
+        stream_copy_to_stream($topContentTempHandle, $contentXmlHandle);
+        fclose($topContentTempHandle);
+        unlink($topContentTempPathname);
 
         foreach ($worksheets as $worksheet) {
             // write the "<table:table>" node, with the final sheet's name

--- a/tests/Reader/CSV/SpoutTestStream.php
+++ b/tests/Reader/CSV/SpoutTestStream.php
@@ -19,6 +19,9 @@ class SpoutTestStream
     /** @var resource */
     private $fileHandle;
 
+    /** @var null|resource */
+    public $context;
+
     /**
      * @param string $path
      * @param int    $flag

--- a/tests/Reader/CSV/SpoutTestStream.php
+++ b/tests/Reader/CSV/SpoutTestStream.php
@@ -13,14 +13,14 @@ class SpoutTestStream
     public const PATH_TO_CSV_RESOURCES = 'tests/resources/csv/';
     public const CSV_EXTENSION = '.csv';
 
+    /** @var null|resource */
+    public $context;
+
     /** @var int */
     private $position;
 
     /** @var resource */
     private $fileHandle;
-
-    /** @var null|resource */
-    public $context;
 
     /**
      * @param string $path


### PR DESCRIPTION
This is a re-roll of https://github.com/openspout/openspout/pull/101 against the 3.x branch, allowing users to have a version that supports both PHP 7.4 (the last version compatible with the old Box-maintained lib) and 8.2, vs. needing an intermediate runtime version step (7.4 -> 8.1, then lib version 3.x -> 4.x, then 8.1 -> 8.2).