### PR TITLE
Changed worksheet filepath in xls/xl/worksheets

### DIFF
--- a/src/Writer/XLSX/Manager/WorkbookManager.php
+++ b/src/Writer/XLSX/Manager/WorkbookManager.php
@@ -35,7 +35,7 @@ class WorkbookManager extends WorkbookManagerAbstract
     {
         $worksheetFilesFolder = $this->fileSystemHelper->getXlWorksheetsFolder();
 
-        return $worksheetFilesFolder.'/'.strtolower($sheet->getName()).'.xml';
+        return $worksheetFilesFolder.'/sheet' . ($sheet->getIndex() + 1) . '.xml';
     }
 
     /**


### PR DESCRIPTION
Hello. I needed to rename the prefix DEFAULT_SHEET_NAME_PREFIX of the sheet name in the file src/Writer/Common/Entity/Sheet.php. I redefined this file, changed the prefix. The Excel file has been created successfully. It had the name of the sheet that I needed. But the data on the sheet was not displayed. I studied the xlsx files created by Microsoft Excel and found out that in the xls/xl/worksheets directory, the sheets are always named sheet1.xml , sheet2.xml regardless of how the sheets are named.
Also in your file src/Writer/XLSX/Helper/FileSystemHelper.php on line 193: "worksheets/sheet'.$worksheetId.'.xml", i.e. you are correctly linking to an XML file with the name sheet1.xml , sheet2.xml... The filename is hardcoded here. I suggest that in the correction, specify a hard name. This will allow you to change the name of the sheet.
I do not know if you still support the 3.x branch, but I think my fix would not hurt.
Thanks for your work