### PR TITLE
Fix date pattern detection/double-quoted strings

### DIFF
--- a/src/Reader/XLSX/Manager/StyleManager.php
+++ b/src/Reader/XLSX/Manager/StyleManager.php
@@ -296,6 +296,10 @@ class StyleManager implements StyleManagerInterface
         $formatCode = preg_replace($pattern, '', $formatCode);
         \assert(null !== $formatCode);
 
+        // Remove strings in double quotes, as they won't be interpreted as date format characters
+        $formatCode = preg_replace('/"[^"]+"/','', $formatCode);
+        \assert(null !== $formatCode);
+
         // custom date formats contain specific characters to represent the date:
         // e - yy - m - d - h - s
         // and all of their variants (yyyy - mm - dd...)

--- a/src/Reader/XLSX/Manager/StyleManager.php
+++ b/src/Reader/XLSX/Manager/StyleManager.php
@@ -297,7 +297,7 @@ class StyleManager implements StyleManagerInterface
         \assert(null !== $formatCode);
 
         // Remove strings in double quotes, as they won't be interpreted as date format characters
-        $formatCode = preg_replace('/"[^"]+"/','', $formatCode);
+        $formatCode = preg_replace('/"[^"]+"/', '', $formatCode);
         \assert(null !== $formatCode);
 
         // custom date formats contain specific characters to represent the date:

--- a/tests/Reader/XLSX/Manager/StyleManagerTest.php
+++ b/tests/Reader/XLSX/Manager/StyleManagerTest.php
@@ -111,6 +111,7 @@ final class StyleManagerTest extends TestCase
             ['GENERAL', false],
             ['\ma\yb\e', false],
             ['[Red]foo;', false],
+            ['foo "mm/dd/yy"', false],
         ];
     }
 

--- a/tests/Writer/ODS/WriterTest.php
+++ b/tests/Writer/ODS/WriterTest.php
@@ -113,7 +113,7 @@ final class WriterTest extends TestCase
         $writer->setCurrentSheet($dummySheet);
     }
 
-    public static function dataProviderForTestSetCreator(): array
+    public static function provideSetCreatorCases(): iterable
     {
         return [
             ['Test creator', 'Test creator'],
@@ -122,7 +122,7 @@ final class WriterTest extends TestCase
     }
 
     /**
-     * @dataProvider dataProviderForTestSetCreator
+     * @dataProvider provideSetCreatorCases
      */
     public function testSetCreator(?string $expected, string $actual): void
     {

--- a/tests/Writer/ODS/WriterTest.php
+++ b/tests/Writer/ODS/WriterTest.php
@@ -113,6 +113,9 @@ final class WriterTest extends TestCase
         $writer->setCurrentSheet($dummySheet);
     }
 
+    /**
+     * @return array{0: ?string, 1: string}[]
+     */
     public static function provideSetCreatorCases(): iterable
     {
         return [

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -116,7 +116,7 @@ final class WriterTest extends TestCase
         $this->expectNotToPerformAssertions();
     }
 
-    public static function dataProviderForTestSetCreator(): array
+    public static function provideSetCreatorCases(): iterable
     {
         return [
             ['Test creator', 'Test creator'],
@@ -125,7 +125,7 @@ final class WriterTest extends TestCase
     }
 
     /**
-     * @dataProvider dataProviderForTestSetCreator
+     * @dataProvider provideSetCreatorCases
      */
     public function testSetCreator(?string $expected, string $actual): void
     {

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -116,6 +116,9 @@ final class WriterTest extends TestCase
         $this->expectNotToPerformAssertions();
     }
 
+    /**
+     * @return array{0: ?string, 1: string}[]
+     */
     public static function provideSetCreatorCases(): iterable
     {
         return [


### PR DESCRIPTION
Excel uses double-quoted strings to indicate raw text. So when looking for date format patterns in custom cell formats, we should ignore double-quoted strings to prevent false-positives.
