### PR TITLE
Writer\XLSX: add support for DateInterval

### DIFF
--- a/src/Common/Entity/Cell/DateIntervalCell.php
+++ b/src/Common/Entity/Cell/DateIntervalCell.php
@@ -12,6 +12,12 @@ final class DateIntervalCell extends Cell
 {
     private DateInterval $value;
 
+    /**
+     * For Excel make sure to set a format onto the style (Style::setFormat()) with the left most unit enclosed with
+     *   brackets: '[h]:mm', '[hh]:mm:ss', '[m]:ss', '[s]', etc.
+     * This makes sure excel knows what to do with the remaining time that exceeds this unit. Without brackets Excel
+     *   will interpret the value as date time and not duration if it is greater or equal 1.
+     */
     public function __construct(DateInterval $value, ?Style $style)
     {
         $this->value = $value;

--- a/src/Writer/XLSX/Helper/DateIntervalHelper.php
+++ b/src/Writer/XLSX/Helper/DateIntervalHelper.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSpout\Writer\XLSX\Helper;
+
+use DateInterval;
+
+/**
+ * @internal
+ */
+final class DateIntervalHelper
+{
+    /**
+     * Excel stores time durations as fractions of days:
+     *   A value of 1 equals 24 hours, a value of 0.5 equals 12 hours, etc.
+     *
+     * Note: Excel can only display durations up to hours and it will only auto-detect this value as an actual duration
+     *     if the value is less than 1, even if you specify a custom format such als "hh:mm:ss".
+     *   To force the display into a duration format, you have to use the brackets around the left most unit
+     *     of the format, e.g. "[h]:mm" or "[mm]:ss", which tells Excel to use up all the remaining time exceeding
+     *     this unit and put it in this last unit.
+     */
+    public static function toExcel(DateInterval $interval): float
+    {
+        // For years and months we can only use the respective average of days here - this won't be accurate, but the
+        // DateInterval doesn't give us more details on those:
+        return $interval->y * 365.25
+            + $interval->m * 30.437
+            + $interval->d
+            + $interval->h / 24
+            + $interval->i / 24 / 60
+            + $interval->s / 24 / 60 / 60;
+    }
+}

--- a/src/Writer/XLSX/Manager/WorksheetManager.php
+++ b/src/Writer/XLSX/Manager/WorksheetManager.php
@@ -17,6 +17,7 @@ use OpenSpout\Writer\Common\Manager\RegisteredStyle;
 use OpenSpout\Writer\Common\Manager\Style\StyleMerger;
 use OpenSpout\Writer\Common\Manager\WorksheetManagerInterface;
 use OpenSpout\Writer\XLSX\Helper\DateHelper;
+use OpenSpout\Writer\XLSX\Helper\DateIntervalHelper;
 use OpenSpout\Writer\XLSX\Manager\Style\StyleManager;
 use OpenSpout\Writer\XLSX\Options;
 
@@ -200,6 +201,8 @@ final class WorksheetManager implements WorksheetManagerInterface
             $cellXML .= '><f>'.substr($cell->getValue(), 1).'</f></c>';
         } elseif ($cell instanceof Cell\DateTimeCell) {
             $cellXML .= '><v>'.DateHelper::toExcel($cell->getValue()).'</v></c>';
+        } elseif ($cell instanceof Cell\DateIntervalCell) {
+            $cellXML .= '><v>'.DateIntervalHelper::toExcel($cell->getValue()).'</v></c>';
         } elseif ($cell instanceof Cell\ErrorCell) {
             // only writes the error value if it's a string
             $cellXML .= ' t="e"><v>'.$cell->getRawValue().'</v></c>';

--- a/tests/Writer/XLSX/Helper/DateIntervalHelperTest.php
+++ b/tests/Writer/XLSX/Helper/DateIntervalHelperTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Writer\XLSX\Helper;
+
+use DateInterval;
+use OpenSpout\Writer\XLSX\Helper\DateIntervalHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(DateIntervalHelper::class)]
+final class DateIntervalHelperTest extends TestCase
+{
+    #[DataProvider('provideDateIntervalToExcelCases')]
+    public function testToExcel(DateInterval $dateTime, float $expected): void
+    {
+        self::assertEqualsWithDelta($expected, DateIntervalHelper::toExcel($dateTime), 1E-5);
+    }
+
+    /**
+     * @return array<array-key, array<array-key, DateInterval|float|int>>
+     */
+    public static function provideDateIntervalToExcelCases(): array
+    {
+        return [
+            [DateInterval::createFromDateString('1 year'), 365.25],
+            [DateInterval::createFromDateString('2 years'), 730.5],
+            [DateInterval::createFromDateString('1 month'), 30.437],
+            [DateInterval::createFromDateString('2 months'), 60.874],
+            [DateInterval::createFromDateString('1 day'), 1],
+            [DateInterval::createFromDateString('2 days'), 2],
+            [DateInterval::createFromDateString('1 hour'), 0.04166666666],
+            [DateInterval::createFromDateString('2 hours'), 0.08333333333],
+            [DateInterval::createFromDateString('1 minute'), 1 / 24 / 60],
+            [DateInterval::createFromDateString('2 minutes'), 2 / 24 / 60],
+            [DateInterval::createFromDateString('1 second'), 1 / 24 / 60 / 60],
+            [DateInterval::createFromDateString('2 seconds'), 2 / 24 / 60 / 60],
+            [new DateInterval('PT12H30M0S'), 0.5 + 30 / 24 / 60],
+        ];
+    }
+}


### PR DESCRIPTION
Adds Excel support for DateIntervals (fixes #176).

I'm not sure whether there is an option to specify formats for Excel only. Otherwise I would have requested a valid Excel-Format in the DateIntervalCell constructor.

Without the right format on the Style, it won't work in Excel.