### PR TITLE
Apply removing undefined variable in catch block

### DIFF
--- a/src/Reader/ODS/Helper/SettingsHelper.php
+++ b/src/Reader/ODS/Helper/SettingsHelper.php
@@ -43,7 +43,7 @@ final class SettingsHelper
                     break;
                 }
             }
-        } catch (XMLProcessingException $exception) {  // @codeCoverageIgnore
+        } catch (XMLProcessingException) {  // @codeCoverageIgnore
             // do nothing
         }
 

--- a/src/Reader/XLSX/Manager/SharedStringsCaching/InMemoryStrategy.php
+++ b/src/Reader/XLSX/Manager/SharedStringsCaching/InMemoryStrategy.php
@@ -66,7 +66,7 @@ final class InMemoryStrategy implements CachingStrategyInterface
     {
         try {
             return $this->inMemoryCache->offsetGet($sharedStringIndex);
-        } catch (RuntimeException $e) {
+        } catch (RuntimeException) {
             throw new SharedStringNotFoundException("Shared string not found for index: {$sharedStringIndex}");
         }
     }

--- a/tests/Reader/ODS/ReaderTest.php
+++ b/tests/Reader/ODS/ReaderTest.php
@@ -246,7 +246,7 @@ final class ReaderTest extends TestCase
             // using @ to prevent warnings/errors from being displayed
             @$this->getAllRowsForFile($fileName);
             self::fail('An exception should have been thrown');
-        } catch (IOException $exception) {
+        } catch (IOException) {
             $duration = microtime(true) - $startTime;
             self::assertLessThan(10, $duration, 'Entities should not be expanded and therefore take more than 10 seconds to be parsed.');
 

--- a/tests/Reader/XLSX/Helper/CellValueFormatterTest.php
+++ b/tests/Reader/XLSX/Helper/CellValueFormatterTest.php
@@ -136,7 +136,7 @@ final class CellValueFormatterTest extends TestCase
                 self::assertInstanceOf(DateTimeCell::class, $result);
                 self::assertSame($expectedDateAsString, $result->getValue()->format('Y-m-d H:i:s'));
             }
-        } catch (InvalidValueException $exception) {
+        } catch (InvalidValueException) {
             // do nothing
         }
     }

--- a/tests/Reader/XLSX/ReaderTest.php
+++ b/tests/Reader/XLSX/ReaderTest.php
@@ -462,7 +462,7 @@ final class ReaderTest extends TestCase
             // using @ to prevent warnings/errors from being displayed
             @$this->getAllRowsForFile('attack_billion_laughs.xlsx');
             self::fail('An exception should have been thrown');
-        } catch (IOException $exception) {
+        } catch (IOException) {
             $duration = microtime(true) - $startTime;
             self::assertLessThan(10, $duration, 'Entities should not be expanded and therefore take more than 10 seconds to be parsed.');
 

--- a/tests/Writer/Common/Manager/Style/StyleRegistryTest.php
+++ b/tests/Writer/Common/Manager/Style/StyleRegistryTest.php
@@ -50,7 +50,7 @@ final class StyleRegistryTest extends TestCase
         try {
             (new Style())->getId();
             self::fail('Style::getId should never be called before registration');
-        } catch (AssertionError $assertionError) {
+        } catch (AssertionError) {
         }
     }
 


### PR DESCRIPTION
# Changed log

- According to the [reference](https://wiki.php.net/rfc/non-capturing_catches), it should remove undefined variable in the catch block and the feature is available since the `PHP 8.0` version is released. 