### PR TITLE
Replace the array_merge with spread array operator

### DIFF
--- a/tests/Reader/XLSX/ReaderTest.php
+++ b/tests/Reader/XLSX/ReaderTest.php
@@ -234,7 +234,7 @@ final class ReaderTest extends TestCase
             array_fill(0, 10, $expectedDate),
             array_fill(0, 10, $expectedDate),
             array_fill(0, 10, $expectedDate),
-            array_merge(array_fill(0, 7, $expectedDate), ['', '', '']),
+            [...array_fill(0, 7, $expectedDate), '', '', ''],
         ];
 
         self::assertEquals($expectedRows, $allRows);


### PR DESCRIPTION
# Changed log

- According to the [reference](https://wiki.php.net/rfc/spread_operator_for_array), it's great to use the spread array operator to replace the `array_merge` function.
- There're two reasons about using the spread array operator:
  - Spread operator should have a better performance than array_merge and compile time optimization can be performant for constant arrays.
  - `array_merge` only supports array, while the spread operator also supports objects implementing `Traversable`.