### PR TITLE
Apply null to be strict string

### DIFF
--- a/src/Reader/CSV/RowIterator.php
+++ b/src/Reader/CSV/RowIterator.php
@@ -188,14 +188,14 @@ final class RowIterator implements RowIteratorInterface
                 case EncodingHelper::ENCODING_UTF16_LE:
                 case EncodingHelper::ENCODING_UTF32_LE:
                     // remove whitespace from the beginning of a string as fgetcsv() add extra whitespace when it try to explode non UTF-8 data
-                    $cellValue = ltrim($cellValue);
+                    $cellValue = ltrim((string) $cellValue);
 
                     break;
 
                 case EncodingHelper::ENCODING_UTF16_BE:
                 case EncodingHelper::ENCODING_UTF32_BE:
                     // remove whitespace from the end of a string as fgetcsv() add extra whitespace when it try to explode non UTF-8 data
-                    $cellValue = rtrim($cellValue);
+                    $cellValue = rtrim((string) $cellValue);
 
                     break;
             }

--- a/src/Writer/AbstractWriter.php
+++ b/src/Writer/AbstractWriter.php
@@ -58,7 +58,7 @@ abstract class AbstractWriter implements WriterInterface
      */
     final public function openToBrowser($outputFileName): void
     {
-        $this->outputFilePath = basename($outputFileName);
+        $this->outputFilePath = basename((string) $outputFileName);
 
         $resource = fopen('php://output', 'w');
         \assert(false !== $resource);

--- a/tests/Reader/Wrapper/XMLReaderTest.php
+++ b/tests/Reader/Wrapper/XMLReaderTest.php
@@ -101,7 +101,7 @@ final class XMLReaderTest extends TestCase
         $realPathURI = ReflectionHelper::callMethodOnObject($xmlReader, 'getRealPathURIForFileInZip', $zipFilePath, $fileInsideZipPath);
 
         // Normalizing path separators for Windows support
-        $normalizedRealPathURI = str_replace('\\', '/', $realPathURI);
+        $normalizedRealPathURI = str_replace('\\', '/', (string) $realPathURI);
         $normalizedExpectedRealPathURI = str_replace('\\', '/', $expectedRealPathURI);
 
         self::assertSame($normalizedExpectedRealPathURI, $normalizedRealPathURI);


### PR DESCRIPTION
# Changed log

- Apply the null to be strict string because it can avoid presenting deprecated message and pass null parameter to these functions.