### PR TITLE
Fix to array returning formula instead of cell value

### DIFF
--- a/src/Common/Entity/Row.php
+++ b/src/Common/Entity/Row.php
@@ -7,6 +7,7 @@ namespace OpenSpout\Common\Entity;
 use DateInterval;
 use DateTimeInterface;
 use OpenSpout\Common\Entity\Style\Style;
+use OpenSpout\Common\Entity\Cell\FormulaCell;
 
 final class Row
 {
@@ -135,7 +136,9 @@ final class Row
     public function toArray(): array
     {
         return array_map(static function (Cell $cell): null|bool|DateInterval|DateTimeInterface|float|int|string {
-            return $cell->getValue();
+            return $cell instanceof FormulaCell
+                ? $cell->getComputedValue()
+                : $cell->getValue();
         }, $this->cells);
     }
 

--- a/tests/Reader/XLSX/ReaderTest.php
+++ b/tests/Reader/XLSX/ReaderTest.php
@@ -607,6 +607,40 @@ final class ReaderTest extends TestCase
         self::assertEquals($expectedRows, $allRows);
     }
 
+    public function testReadShouldReturnFormulaValues(): void
+    {
+        $allRows = $this->getAllRowsForFile('sheet_with_formulas.xlsx');
+
+        $expectedRows = [
+            [
+                'val1',
+                'val2',
+                'total1',
+                'total2',
+                'DateFunction',
+                'Average',
+            ],
+            [
+                10,
+                20,
+                '30',
+                21,
+                new DateTimeImmutable('2022-05-05'),
+                1.5,
+            ],
+            [
+                11,
+                21,
+                '32',
+                '41',
+                null,
+                null,
+            ]
+        ];
+
+        self::assertEquals($expectedRows, $allRows);
+    }
+
     public function testReadMultipleTimesShouldRewindReader(): void
     {
         $allRows = [];


### PR DESCRIPTION
In [v4.16.0](https://github.com/openspout/openspout/releases/tag/v4.16.0) was introduced a breaking change due to returning formula values as-is so $row->toArray() in ExcelReader is not returning the cell value anymore. This PR adds a safety check to return the cell value on the toArray function of Row to mantain backwards compatibility with 4.x releases.