### PR TITLE
Allow passing options to Reader-/WriterFactory

### DIFF
--- a/src/Reader/CSV/Options.php
+++ b/src/Reader/CSV/Options.php
@@ -12,4 +12,20 @@ final class Options
     public string $FIELD_DELIMITER = ',';
     public string $FIELD_ENCLOSURE = '"';
     public string $ENCODING = EncodingHelper::ENCODING_UTF8;
+
+    /**
+     * @param array<string, mixed> $options Array of options
+     *
+     * @return static
+     */
+    public static function fromArray(array $options): static
+    {
+        $self = new self();
+        $self->SHOULD_PRESERVE_EMPTY_ROWS = $options['SHOULD_PRESERVE_EMPTY_ROWS'] ?? $self->SHOULD_PRESERVE_EMPTY_ROWS;
+        $self->FIELD_DELIMITER = $options['FIELD_DELIMITER'] ?? $self->FIELD_DELIMITER;
+        $self->FIELD_ENCLOSURE = $options['FIELD_ENCLOSURE'] ?? $self->FIELD_ENCLOSURE;
+        $self->ENCODING = $options['ENCODING'] ?? $self->ENCODING;
+
+        return $self;
+    }
 }

--- a/src/Reader/Common/Creator/ReaderFactory.php
+++ b/src/Reader/Common/Creator/ReaderFactory.php
@@ -6,9 +6,12 @@ namespace OpenSpout\Reader\Common\Creator;
 
 use OpenSpout\Common\Exception\IOException;
 use OpenSpout\Common\Exception\UnsupportedTypeException;
+use OpenSpout\Reader\CSV\Options as CSVReaderOptions;
 use OpenSpout\Reader\CSV\Reader as CSVReader;
+use OpenSpout\Reader\ODS\Options as ODSReaderOptions;
 use OpenSpout\Reader\ODS\Reader as ODSReader;
 use OpenSpout\Reader\ReaderInterface;
+use OpenSpout\Reader\XLSX\Options as XLSXReaderOptions;
 use OpenSpout\Reader\XLSX\Reader as XLSXReader;
 
 /**
@@ -20,18 +23,19 @@ final class ReaderFactory
     /**
      * Creates a reader by file extension.
      *
-     * @param string $path The path to the spreadsheet file. Supported extensions are .csv,.ods and .xlsx
+     * @param string               $path    The path to the spreadsheet file. Supported extensions are .csv,.ods and .xlsx
+     * @param array<string, mixed> $options Array of options
      *
      * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
      */
-    public static function createFromFile(string $path): ReaderInterface
+    public static function createFromFile(string $path, array $options = []): ReaderInterface
     {
         $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
 
         return match ($extension) {
-            'csv' => new CSVReader(),
-            'xlsx' => new XLSXReader(),
-            'ods' => new ODSReader(),
+            'csv' => new CSVReader(CSVReaderOptions::fromArray($options)),
+            'xlsx' => new XLSXReader(XLSXReaderOptions::fromArray($options)),
+            'ods' => new ODSReader(ODSReaderOptions::fromArray($options)),
             default => throw new UnsupportedTypeException('No readers supporting the given type: '.$extension),
         };
     }
@@ -39,12 +43,13 @@ final class ReaderFactory
     /**
      * Creates a reader by mime type.
      *
-     * @param string $path the path to the spreadsheet file
+     * @param string               $path    the path to the spreadsheet file
+     * @param array<string, mixed> $options Array of options
      *
      * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
      * @throws \OpenSpout\Common\Exception\IOException
      */
-    public static function createFromFileByMimeType(string $path): ReaderInterface
+    public static function createFromFileByMimeType(string $path, array $options = []): ReaderInterface
     {
         if (!file_exists($path)) {
             throw new IOException("Could not open {$path} for reading! File does not exist.");
@@ -53,9 +58,9 @@ final class ReaderFactory
         $mime_type = mime_content_type($path);
 
         return match ($mime_type) {
-            'application/csv', 'text/csv', 'text/plain' => new CSVReader(),
-            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => new XLSXReader(),
-            'application/vnd.oasis.opendocument.spreadsheet' => new ODSReader(),
+            'application/csv', 'text/csv', 'text/plain' => new CSVReader(CSVReaderOptions::fromArray($options)),
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => new XLSXReader(XLSXReaderOptions::fromArray($options)),
+            'application/vnd.oasis.opendocument.spreadsheet' => new ODSReader(ODSReaderOptions::fromArray($options)),
             default => throw new UnsupportedTypeException('No readers supporting the given type: '.$mime_type),
         };
     }

--- a/src/Reader/ODS/Options.php
+++ b/src/Reader/ODS/Options.php
@@ -8,4 +8,18 @@ final class Options
 {
     public bool $SHOULD_FORMAT_DATES = false;
     public bool $SHOULD_PRESERVE_EMPTY_ROWS = false;
+
+    /**
+     * @param array<string, mixed> $options Array of options
+     *
+     * @return static
+     */
+    public static function fromArray(array $options): static
+    {
+        $self = new self();
+        $self->SHOULD_FORMAT_DATES = $options['SHOULD_FORMAT_DATES'] ?? $self->SHOULD_FORMAT_DATES;
+        $self->SHOULD_PRESERVE_EMPTY_ROWS = $options['SHOULD_PRESERVE_EMPTY_ROWS'] ?? $self->SHOULD_PRESERVE_EMPTY_ROWS;
+
+        return $self;
+    }
 }

--- a/src/Reader/XLSX/Options.php
+++ b/src/Reader/XLSX/Options.php
@@ -13,4 +13,20 @@ final class Options
     public bool $SHOULD_FORMAT_DATES = false;
     public bool $SHOULD_PRESERVE_EMPTY_ROWS = false;
     public bool $SHOULD_USE_1904_DATES = false;
+
+    /**
+     * @param array<string, mixed> $options Array of options
+     *
+     * @return static
+     */
+    public static function fromArray(array $options): static
+    {
+        $self = new self();
+        $self->SHOULD_FORMAT_DATES = $options['SHOULD_FORMAT_DATES'] ?? $self->SHOULD_FORMAT_DATES;
+        $self->SHOULD_PRESERVE_EMPTY_ROWS = $options['SHOULD_PRESERVE_EMPTY_ROWS'] ?? $self->SHOULD_PRESERVE_EMPTY_ROWS;
+        $self->SHOULD_USE_1904_DATES = $options['SHOULD_USE_1904_DATES'] ?? $self->SHOULD_USE_1904_DATES;
+        $self->setTempFolder($options['tempFolder'] ?? $self->getTempFolder());
+
+        return $self;
+    }
 }

--- a/src/Writer/CSV/Options.php
+++ b/src/Writer/CSV/Options.php
@@ -12,4 +12,20 @@ final class Options
 
     /** @var positive-int */
     public int $FLUSH_THRESHOLD = 500;
+
+    /**
+     * @param array<string, mixed> $options Array of options
+     *
+     * @return static
+     */
+    public static function fromArray(array $options): static
+    {
+        $self = new self();
+        $self->FIELD_DELIMITER = $options['FIELD_DELIMITER'] ?? $self->FIELD_DELIMITER;
+        $self->FIELD_ENCLOSURE = $options['FIELD_ENCLOSURE'] ?? $self->FIELD_ENCLOSURE;
+        $self->SHOULD_ADD_BOM = $options['SHOULD_ADD_BOM'] ?? $self->SHOULD_ADD_BOM;
+        $self->FLUSH_THRESHOLD = $options['FLUSH_THRESHOLD'] ?? $self->FLUSH_THRESHOLD;
+
+        return $self;
+    }
 }

--- a/src/Writer/Common/AbstractOptions.php
+++ b/src/Writer/Common/AbstractOptions.php
@@ -7,6 +7,7 @@ namespace OpenSpout\Writer\Common;
 use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Common\TempFolderOptionTrait;
 
+/** @phpstan-consistent-constructor */
 abstract class AbstractOptions
 {
     use TempFolderOptionTrait;
@@ -22,6 +23,26 @@ abstract class AbstractOptions
     public function __construct()
     {
         $this->DEFAULT_ROW_STYLE = new Style();
+    }
+
+    /**
+     * @param array<string, mixed> $options Array of options
+     *
+     * @return static
+     */
+    public static function fromArray(array $options): static
+    {
+        $self = new static();
+        $self->DEFAULT_ROW_STYLE = $options['DEFAULT_ROW_STYLE'] ?? $self->DEFAULT_ROW_STYLE;
+        $self->DEFAULT_ROW_STYLE->setFontSize($options['DEFAULT_FONT_SIZE'] ?? $self->DEFAULT_ROW_STYLE->getFontSize());
+        $self->DEFAULT_ROW_STYLE->setFontName($options['DEFAULT_FONT_NAME'] ?? $self->DEFAULT_ROW_STYLE->getFontName());
+        $self->DEFAULT_ROW_STYLE->setFontColor($options['DEFAULT_FONT_COLOR'] ?? $self->DEFAULT_ROW_STYLE->getFontColor());
+        $self->SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY = $options['SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY'] ?? $self->SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY;
+        $self->DEFAULT_COLUMN_WIDTH = $options['DEFAULT_COLUMN_WIDTH'] ?? $self->DEFAULT_COLUMN_WIDTH;
+        $self->DEFAULT_ROW_HEIGHT = $options['DEFAULT_ROW_HEIGHT'] ?? $self->DEFAULT_ROW_HEIGHT;
+        $self->setTempFolder($options['tempFolder'] ?? $self->getTempFolder());
+
+        return $self;
     }
 
     /**

--- a/src/Writer/Common/Creator/WriterFactory.php
+++ b/src/Writer/Common/Creator/WriterFactory.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace OpenSpout\Writer\Common\Creator;
 
 use OpenSpout\Common\Exception\UnsupportedTypeException;
+use OpenSpout\Writer\CSV\Options as CSVWriterOptions;
 use OpenSpout\Writer\CSV\Writer as CSVWriter;
+use OpenSpout\Writer\ODS\Options as ODSWriterOptions;
 use OpenSpout\Writer\ODS\Writer as ODSWriter;
 use OpenSpout\Writer\WriterInterface;
+use OpenSpout\Writer\XLSX\Options as XLSXWriterOptions;
 use OpenSpout\Writer\XLSX\Writer as XLSXWriter;
 
 /**
@@ -19,18 +22,19 @@ final class WriterFactory
     /**
      * This creates an instance of the appropriate writer, given the extension of the file to be written.
      *
-     * @param string $path The path to the spreadsheet file. Supported extensions are .csv,.ods and .xlsx
+     * @param string $path                  The path to the spreadsheet file. Supported extensions are .csv,.ods and .xlsx
+     * @param array<string, mixed> $options Array of options
      *
      * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
      */
-    public static function createFromFile(string $path): WriterInterface
+    public static function createFromFile(string $path, array $options = []): WriterInterface
     {
         $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
 
         return match ($extension) {
-            'csv' => new CSVWriter(),
-            'xlsx' => new XLSXWriter(),
-            'ods' => new ODSWriter(),
+            'csv' => new CSVWriter(CSVWriterOptions::fromArray($options)),
+            'xlsx' => new XLSXWriter(XLSXWriterOptions::fromArray($options)),
+            'ods' => new ODSWriter(ODSWriterOptions::fromArray($options)),
             default => throw new UnsupportedTypeException('No writers supporting the given type: '.$extension),
         };
     }

--- a/src/Writer/XLSX/Options.php
+++ b/src/Writer/XLSX/Options.php
@@ -35,6 +35,19 @@ final class Options extends AbstractOptions
     }
 
     /**
+     * @param array<string, mixed> $options Array of options
+     *
+     * @return static
+     */
+    public static function fromArray(array $options): static
+    {
+        $self = parent::fromArray($options);
+        $self->SHOULD_USE_INLINE_STRINGS = $options['SHOULD_USE_INLINE_STRINGS'] ?? $self->SHOULD_USE_INLINE_STRINGS;
+
+        return $self;
+    }
+
+    /**
      * Row coordinates are indexed from 1, columns from 0 (A = 0),
      * so a merge B2:G2 looks like $writer->mergeCells(1, 2, 6, 2);.
      *

--- a/tests/Reader/CSV/ReaderTest.php
+++ b/tests/Reader/CSV/ReaderTest.php
@@ -428,4 +428,22 @@ final class ReaderTest extends TestCase
 
         return $allRows;
     }
+
+    public function testShouldSetOptionsFromArray(): void
+    {
+        $FIELD_DELIMITER = ';';
+        $FIELD_ENCLOSURE = '\'';
+        $ENCODING = 'testencoding';
+        $options = Options::fromArray([
+            'SHOULD_PRESERVE_EMPTY_ROWS' => true,
+            'FIELD_DELIMITER' => $FIELD_DELIMITER,
+            'FIELD_ENCLOSURE' => $FIELD_ENCLOSURE,
+            'ENCODING' => $ENCODING,
+        ]);
+
+        self::assertTrue($options->SHOULD_PRESERVE_EMPTY_ROWS);
+        self::assertSame($FIELD_DELIMITER, $options->FIELD_DELIMITER);
+        self::assertSame($FIELD_DELIMITER, $options->FIELD_DELIMITER);
+        self::assertSame($ENCODING, $options->ENCODING);
+    }
 }

--- a/tests/Reader/ODS/ReaderTest.php
+++ b/tests/Reader/ODS/ReaderTest.php
@@ -476,4 +476,15 @@ final class ReaderTest extends TestCase
 
         return $allRows;
     }
+
+    public function testShouldSetOptionsFromArray(): void
+    {
+        $options = Options::fromArray([
+            'SHOULD_FORMAT_DATES' => true,
+            'SHOULD_PRESERVE_EMPTY_ROWS' => true,
+        ]);
+
+        self::assertTrue($options->SHOULD_FORMAT_DATES);
+        self::assertTrue($options->SHOULD_PRESERVE_EMPTY_ROWS);
+    }
 }

--- a/tests/Reader/XLSX/ReaderTest.php
+++ b/tests/Reader/XLSX/ReaderTest.php
@@ -811,4 +811,20 @@ final class ReaderTest extends TestCase
 
         return $allRows;
     }
+
+    public function testShouldSetOptionsFromArray(): void
+    {
+        $tempFolder= (new TestUsingResource())->getTempFolderPath();
+        $options = Options::fromArray([
+            'SHOULD_FORMAT_DATES' => true,
+            'SHOULD_PRESERVE_EMPTY_ROWS' => true,
+            'SHOULD_USE_1904_DATES' => true,
+            'tempFolder' => $tempFolder,
+        ]);
+
+        self::assertTrue($options->SHOULD_FORMAT_DATES);
+        self::assertTrue($options->SHOULD_PRESERVE_EMPTY_ROWS);
+        self::assertTrue($options->SHOULD_USE_1904_DATES);
+        self::assertSame($tempFolder, $options->getTempFolder());
+    }
 }

--- a/tests/Writer/CSV/WriterTest.php
+++ b/tests/Writer/CSV/WriterTest.php
@@ -219,6 +219,25 @@ final class WriterTest extends TestCase
         self::assertSame($options->FLUSH_THRESHOLD, $writer->getOptions()->FLUSH_THRESHOLD);
     }
 
+    public function testShouldSetOptionsFromArray(): void
+    {
+        $FLUSH_THRESHOLD = random_int(100, 199);
+        $FIELD_DELIMITER = ';';
+        $FIELD_ENCLOSURE = '\'';
+        $options = Options::fromArray([
+            'FLUSH_THRESHOLD' => $FLUSH_THRESHOLD,
+            'FIELD_DELIMITER' => $FIELD_DELIMITER,
+            'FIELD_ENCLOSURE' => $FIELD_ENCLOSURE,
+            'SHOULD_ADD_BOM' => false,
+        ]);
+        $writer = new Writer($options);
+
+        self::assertSame($FLUSH_THRESHOLD, $writer->getOptions()->FLUSH_THRESHOLD);
+        self::assertSame($FIELD_DELIMITER, $writer->getOptions()->FIELD_DELIMITER);
+        self::assertSame($FIELD_ENCLOSURE, $writer->getOptions()->FIELD_ENCLOSURE);
+        self::assertFalse($writer->getOptions()->SHOULD_ADD_BOM);
+    }
+
     public function testWriteToCompressedStream(): void
     {
         $fileName = 'csv_compressed.csv.gz';

--- a/tests/Writer/ODS/WriterTest.php
+++ b/tests/Writer/ODS/WriterTest.php
@@ -488,6 +488,34 @@ final class WriterTest extends TestCase
         self::assertSame($options->DEFAULT_COLUMN_WIDTH, $writer->getOptions()->DEFAULT_COLUMN_WIDTH);
     }
 
+    public function testShouldSetOptionsFromArray(): void
+    {
+        $DEFAULT_FONT_SIZE = random_int(20, 99);
+        $DEFAULT_FONT_NAME = 'testfont';
+        $DEFAULT_FONT_COLOR = 'testcolor';
+        $DEFAULT_COLUMN_WIDTH = (float) random_int(100, 199);
+        $DEFAULT_ROW_HEIGHT = (float) random_int(100, 199);
+        $tempFolder= (new TestUsingResource())->getTempFolderPath();
+        $options = Options::fromArray([
+            'DEFAULT_FONT_SIZE' => $DEFAULT_FONT_SIZE,
+            'DEFAULT_FONT_NAME' => $DEFAULT_FONT_NAME,
+            'DEFAULT_FONT_COLOR' => $DEFAULT_FONT_COLOR,
+            'SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY' => false,
+            'DEFAULT_COLUMN_WIDTH' => $DEFAULT_COLUMN_WIDTH,
+            'DEFAULT_ROW_HEIGHT' => $DEFAULT_ROW_HEIGHT,
+            'tempFolder' => $tempFolder,
+        ]);
+        $writer = new Writer($options);
+
+        self::assertSame($DEFAULT_FONT_SIZE, $writer->getOptions()->DEFAULT_ROW_STYLE->getFontSize());
+        self::assertSame($DEFAULT_FONT_NAME, $writer->getOptions()->DEFAULT_ROW_STYLE->getFontName());
+        self::assertSame($DEFAULT_FONT_COLOR, $writer->getOptions()->DEFAULT_ROW_STYLE->getFontColor());
+        self::assertSame($DEFAULT_COLUMN_WIDTH, $writer->getOptions()->DEFAULT_COLUMN_WIDTH);
+        self::assertFalse($writer->getOptions()->SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY);
+        self::assertSame($DEFAULT_ROW_HEIGHT, $writer->getOptions()->DEFAULT_ROW_HEIGHT);
+        self::assertSame($tempFolder, $writer->getOptions()->getTempFolder());
+    }
+
     public function testSetAutofilterShouldWriteCorrectData(): void
     {
         $fileName = 'test_set_autofilter_should_write_correct_data.ods';

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -602,6 +602,36 @@ final class WriterTest extends TestCase
         self::assertSame($options->DEFAULT_COLUMN_WIDTH, $writer->getOptions()->DEFAULT_COLUMN_WIDTH);
     }
 
+    public function testShouldSetOptionsFromArray(): void
+    {
+        $DEFAULT_FONT_SIZE = random_int(20, 99);
+        $DEFAULT_FONT_NAME = 'testfont';
+        $DEFAULT_FONT_COLOR = 'testcolor';
+        $DEFAULT_COLUMN_WIDTH = (float) random_int(100, 199);
+        $DEFAULT_ROW_HEIGHT = (float) random_int(100, 199);
+        $tempFolder= (new TestUsingResource())->getTempFolderPath();
+        $options = Options::fromArray([
+            'DEFAULT_FONT_SIZE' => $DEFAULT_FONT_SIZE,
+            'DEFAULT_FONT_NAME' => $DEFAULT_FONT_NAME,
+            'DEFAULT_FONT_COLOR' => $DEFAULT_FONT_COLOR,
+            'SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY' => false,
+            'DEFAULT_COLUMN_WIDTH' => $DEFAULT_COLUMN_WIDTH,
+            'DEFAULT_ROW_HEIGHT' => $DEFAULT_ROW_HEIGHT,
+            'SHOULD_USE_INLINE_STRINGS' => false,
+            'tempFolder' => $tempFolder,
+        ]);
+        $writer = new Writer($options);
+
+        self::assertSame($DEFAULT_FONT_SIZE, $writer->getOptions()->DEFAULT_ROW_STYLE->getFontSize());
+        self::assertSame($DEFAULT_FONT_NAME, $writer->getOptions()->DEFAULT_ROW_STYLE->getFontName());
+        self::assertSame($DEFAULT_FONT_COLOR, $writer->getOptions()->DEFAULT_ROW_STYLE->getFontColor());
+        self::assertSame($DEFAULT_COLUMN_WIDTH, $writer->getOptions()->DEFAULT_COLUMN_WIDTH);
+        self::assertFalse($writer->getOptions()->SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY);
+        self::assertSame($DEFAULT_ROW_HEIGHT, $writer->getOptions()->DEFAULT_ROW_HEIGHT);
+        self::assertFalse($writer->getOptions()->SHOULD_USE_INLINE_STRINGS);
+        self::assertSame($tempFolder, $writer->getOptions()->getTempFolder());
+    }
+
     public function testSheetFilenameAreStoredWithIndex(): void
     {
         $fileName = 'sheet_indexes.xlsx';


### PR DESCRIPTION
Example:
```php
OpenSpout\Reader\Common\Creator\ReaderFactory::createFromFile($path, [
    'SHOULD_FORMAT_DATES' => false,
    'SHOULD_PRESERVE_EMPTY_ROWS' => false,
    'FIELD_DELIMITER' => ';',
    'FIELD_ENCLOSURE' => '\'',
]);
```