### PR TITLE
Add support for headerFooter, fitToHeight/Width, printTitleRows (xlsx only)

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -240,10 +240,31 @@ $options = new Options();
 $options->setPageSetup(new PageSetup(
     PageOrientation::LANDSCAPE,
     PaperSize::A4,
+    0, // ?int fitToHeight
+    1  // ?int fitToWidth
 ));
 
 // set margin in inches: top, right, bottom, left, header, footer
 $options->setPageMargin(new PageMargin(0.75, 0.7, 0.75, 0.7, 0.3, 0.3));
+
+$writer = new Writer($options);
+```
+
+## HeaderFooter
+
+```php
+use OpenSpout\Writer\XLSX\Writer;
+use OpenSpout\Writer\XLSX\Options;
+use OpenSpout\Writer\XLSX\Options\HeaderFooter;
+
+$options = new Options();
+$options->setHeaderFooter(new HeaderFooter(
+    'oddHeader',
+    'oddFooter',
+    'evenHeader',
+    'evenFooter',
+    true  // differentOddEven, default value is false
+));
 
 $writer = new Writer($options);
 ```

--- a/src/Writer/Common/Entity/Sheet.php
+++ b/src/Writer/Common/Entity/Sheet.php
@@ -208,7 +208,7 @@ final class Sheet
     {
         return $this->COLUMN_WIDTHS;
     }
-   
+
     public function getPrintTitleRows(): ?string
     {
         return $this->printTitleRows;
@@ -217,5 +217,5 @@ final class Sheet
     public function setPrintTitleRows(string $printTitleRows): void
     {
         $this->printTitleRows = $printTitleRows;
-    }    
+    }
 }

--- a/src/Writer/Common/Entity/Sheet.php
+++ b/src/Writer/Common/Entity/Sheet.php
@@ -41,6 +41,9 @@ final class Sheet
     /** @var ColumnWidth[] Array of min-max-width arrays */
     private array $COLUMN_WIDTHS = [];
 
+    /** @var string rows to repeat at top */
+    private ?string $printTitleRows = null;
+
     /**
      * @param 0|positive-int $sheetIndex           Index of the sheet, based on order in the workbook (zero-based)
      * @param string         $associatedWorkbookId ID of the sheet's associated workbook
@@ -205,4 +208,14 @@ final class Sheet
     {
         return $this->COLUMN_WIDTHS;
     }
+   
+    public function getPrintTitleRows(): ?string
+    {
+        return $this->printTitleRows;
+    }
+
+    public function setPrintTitleRows(string $printTitleRows): void
+    {
+        $this->printTitleRows = $printTitleRows;
+    }    
 }

--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -310,7 +310,7 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
     public function createContentFiles(Options $options, array $worksheets): self
     {
         $allMergeCells = $options->getMergeCells();
-
+        $pageSetup = $options->getPageSetup();
         foreach ($worksheets as $worksheet) {
             $contentXmlFilePath = $this->getXlWorksheetsFolder().\DIRECTORY_SEPARATOR.basename($worksheet->getFilePath());
             $worksheetFilePointer = fopen($contentXmlFilePath, 'w');
@@ -332,7 +332,9 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
                 fwrite($worksheetFilePointer, '<sheetPr filterMode="false"><pageSetUpPr fitToPage="false"/></sheetPr>');
                 fwrite($worksheetFilePointer, sprintf('<dimension ref="%s"/>', $range));
             }
-
+            if (isset($pageSetup) && $pageSetup->fitToPage) {
+                fwrite($worksheetFilePointer, '<sheetPr><pageSetUpPr fitToPage="true"/></sheetPr>');
+            }
             if (null !== ($sheetView = $sheet->getSheetView())) {
                 fwrite($worksheetFilePointer, '<sheetViews>'.$sheetView->getXml().'</sheetViews>');
             }
@@ -485,13 +487,7 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
             return;
         }
 
-        $xml = '';
-
-        if ($pageSetup->fitToPage) {
-            $xml = '<sheetPr><pageSetUpPr fitToPage="1"/></sheetPr>';
-        }
-
-        $xml .= '<pageSetup';
+        $xml = '<pageSetup';
 
         if (null !== $pageSetup->pageOrientation) {
             $xml .= " orientation=\"{$pageSetup->pageOrientation->value}\"";

--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -370,6 +370,8 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
 
             $this->getXMLFragmentForPageSetup($worksheetFilePointer, $options);
 
+            $this->getXMLFragmentForHeaderFooter($worksheetFilePointer, $options);
+
             // Add the legacy drawing for comments
             fwrite($worksheetFilePointer, '<legacyDrawing r:id="rId_comments_vml1"/>');
 
@@ -431,6 +433,40 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
     /**
      * @param resource $targetResource
      */
+    private function getXMLFragmentForHeaderFooter($targetResource, Options $options): void
+    {
+        $headerFooter = $options->getHeaderFooter();
+        if (null === $headerFooter) {
+            return;
+        }
+       
+        $xml = "<headerFooter differentOddEven=\"{$headerFooter->differentOddEven}\">";
+
+        if (null !== $headerFooter->oddHeader) {
+            $xml .= "<oddHeader>{$headerFooter->oddHeader}</oddHeader>";
+        }
+
+        if (null !== $headerFooter->oddFooter) {
+            $xml .= "<oddFooter>{$headerFooter->oddFooter}</oddFooter>";
+        }
+
+        if (null !== $headerFooter->evenHeader) {
+            $xml .= "<evenHeader>{$headerFooter->evenHeader}</evenHeader>";
+        }
+
+        if (null !== $headerFooter->evenFooter) {
+            $xml .= "<evenFooter>{$headerFooter->evenFooter}</evenFooter>";
+        }
+
+        $xml .= '</headerFooter>';
+
+        fwrite($targetResource, $xml); 
+
+    }
+
+    /**
+     * @param resource $targetResource
+     */
     private function getXMLFragmentForPageSetup($targetResource, Options $options): void
     {
         $pageSetup = $options->getPageSetup();
@@ -446,6 +482,14 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
 
         if (null !== $pageSetup->paperSize) {
             $xml .= " paperSize=\"{$pageSetup->paperSize->value}\"";
+        }
+
+        if (null !== $pageSetup->fitToHeight) {
+            $xml .= " fitToHeight=\"{$pageSetup->fitToHeight}\"";
+        }
+
+        if (null !== $pageSetup->fitToWidth) {
+            $xml .= " fitToWidth=\"{$pageSetup->fitToWidth}\"";
         }
 
         $xml .= '/>';

--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -482,6 +482,8 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
             return;
         }
 
+        $xml = '';
+
         if ($pageSetup->fitToPage) {
             $xml = '<sheetPr><pageSetUpPr fitToPage="1"/></sheetPr>';
         }

--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -219,11 +219,11 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
                     CellHelper::getColumnLettersFromColumnIndex($autofilter->toColumnIndex),
                     $autofilter->toRow
                 );
-                $definedNames .= '<definedName function="false" hidden="true" localSheetId="'.$sheet->getIndex().'" name="_xlnm._FilterDatabase" vbProcedure="false">'.$name.'</definedName>';              
+                $definedNames .= '<definedName function="false" hidden="true" localSheetId="'.$sheet->getIndex().'" name="_xlnm._FilterDatabase" vbProcedure="false">'.$name.'</definedName>';
             }
             if (null !== $printTitleRows = $sheet->getPrintTitleRows()) {
-                $definedNames .= '<definedName name="_xlnm.Print_Titles" localSheetId="'.$sheet->getIndex().'">' . $this->escaper->escape($sheet->getName()) . '!' . $printTitleRows . '</definedName>';
-            }              
+                $definedNames .= '<definedName name="_xlnm.Print_Titles" localSheetId="'.$sheet->getIndex().'">'.$this->escaper->escape($sheet->getName()).'!'.$printTitleRows.'</definedName>';
+            }
         }
         if ('' !== $definedNames) {
             $workbookXmlFileContents .= '<definedNames>'.$definedNames.'</definedNames>';
@@ -444,8 +444,8 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
         if (null === $headerFooter) {
             return;
         }
-       
-        $xml = "<headerFooter";
+
+        $xml = '<headerFooter';
 
         if ($headerFooter->differentOddEven) {
             $xml .= " differentOddEven=\"{$headerFooter->differentOddEven}\"";
@@ -465,7 +465,7 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
             if (null !== $headerFooter->evenHeader) {
                 $xml .= "<evenHeader>{$headerFooter->evenHeader}</evenHeader>";
             }
-    
+
             if (null !== $headerFooter->evenFooter) {
                 $xml .= "<evenFooter>{$headerFooter->evenFooter}</evenFooter>";
             }
@@ -473,8 +473,7 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
 
         $xml .= '</headerFooter>';
 
-        fwrite($targetResource, $xml); 
-
+        fwrite($targetResource, $xml);
     }
 
     /**

--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -440,7 +440,13 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
             return;
         }
        
-        $xml = "<headerFooter differentOddEven=\"{$headerFooter->differentOddEven}\">";
+        $xml = "<headerFooter";
+
+        if ($headerFooter->differentOddEven) {
+            $xml .= " differentOddEven=\"{$headerFooter->differentOddEven}\"";
+        }
+
+        $xml .= '>';
 
         if (null !== $headerFooter->oddHeader) {
             $xml .= "<oddHeader>{$headerFooter->oddHeader}</oddHeader>";
@@ -450,12 +456,14 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
             $xml .= "<oddFooter>{$headerFooter->oddFooter}</oddFooter>";
         }
 
-        if (null !== $headerFooter->evenHeader) {
-            $xml .= "<evenHeader>{$headerFooter->evenHeader}</evenHeader>";
-        }
-
-        if (null !== $headerFooter->evenFooter) {
-            $xml .= "<evenFooter>{$headerFooter->evenFooter}</evenFooter>";
+        if ($headerFooter->differentOddEven) {
+            if (null !== $headerFooter->evenHeader) {
+                $xml .= "<evenHeader>{$headerFooter->evenHeader}</evenHeader>";
+            }
+    
+            if (null !== $headerFooter->evenFooter) {
+                $xml .= "<evenFooter>{$headerFooter->evenFooter}</evenFooter>";
+            }
         }
 
         $xml .= '</headerFooter>';

--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -329,10 +329,13 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
                     CellHelper::getColumnLettersFromColumnIndex($autofilter->toColumnIndex),
                     $autofilter->toRow
                 );
-                fwrite($worksheetFilePointer, '<sheetPr filterMode="false"><pageSetUpPr fitToPage="false"/></sheetPr>');
+                if (isset($pageSetup) && $pageSetup->fitToPage) {
+                    fwrite($worksheetFilePointer, '<sheetPr filterMode="false"><pageSetUpPr fitToPage="true"/></sheetPr>');
+                } else {
+                    fwrite($worksheetFilePointer, '<sheetPr filterMode="false"><pageSetUpPr fitToPage="false"/></sheetPr>');
+                }
                 fwrite($worksheetFilePointer, sprintf('<dimension ref="%s"/>', $range));
-            }
-            if (isset($pageSetup) && $pageSetup->fitToPage) {
+            } elseif (isset($pageSetup) && $pageSetup->fitToPage) {
                 fwrite($worksheetFilePointer, '<sheetPr><pageSetUpPr fitToPage="true"/></sheetPr>');
             }
             if (null !== ($sheetView = $sheet->getSheetView())) {

--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -474,7 +474,11 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
             return;
         }
 
-        $xml = '<pageSetup';
+        if ($pageSetup->fitToPage) {
+            $xml = '<sheetPr><pageSetUpPr fitToPage="1"/></sheetPr>';
+        }
+
+        $xml .= '<pageSetup';
 
         if (null !== $pageSetup->pageOrientation) {
             $xml .= " orientation=\"{$pageSetup->pageOrientation->value}\"";

--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -219,8 +219,11 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
                     CellHelper::getColumnLettersFromColumnIndex($autofilter->toColumnIndex),
                     $autofilter->toRow
                 );
-                $definedNames .= '<definedName function="false" hidden="true" localSheetId="'.$sheet->getIndex().'" name="_xlnm._FilterDatabase" vbProcedure="false">'.$name.'</definedName>';
+                $definedNames .= '<definedName function="false" hidden="true" localSheetId="'.$sheet->getIndex().'" name="_xlnm._FilterDatabase" vbProcedure="false">'.$name.'</definedName>';              
             }
+            if (null !== $printTitleRows = $sheet->getPrintTitleRows()) {
+                $definedNames .= '<definedName name="_xlnm.Print_Titles" localSheetId="'.$sheet->getIndex().'">' . $this->escaper->escape($sheet->getName()) . '!' . $printTitleRows . '</definedName>';
+            }              
         }
         if ('' !== $definedNames) {
             $workbookXmlFileContents .= '<definedNames>'.$definedNames.'</definedNames>';

--- a/src/Writer/XLSX/Options.php
+++ b/src/Writer/XLSX/Options.php
@@ -8,6 +8,7 @@ use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Writer\Common\AbstractOptions;
 use OpenSpout\Writer\XLSX\Options\PageMargin;
 use OpenSpout\Writer\XLSX\Options\PageSetup;
+use OpenSpout\Writer\XLSX\Options\HeaderFooter;
 
 final class Options extends AbstractOptions
 {
@@ -22,6 +23,8 @@ final class Options extends AbstractOptions
     private ?PageMargin $pageMargin = null;
 
     private ?PageSetup $pageSetup = null;
+
+    private ?HeaderFooter $headerFooter = null;
 
     public function __construct()
     {
@@ -88,5 +91,15 @@ final class Options extends AbstractOptions
     public function getPageSetup(): ?PageSetup
     {
         return $this->pageSetup;
+    }
+
+    public function setHeaderFooter(HeaderFooter $headerFooter): void
+    {
+        $this->headerFooter = $headerFooter;
+    }
+
+    public function getHeaderFooter(): ?HeaderFooter
+    {
+        return $this->headerFooter;
     }
 }

--- a/src/Writer/XLSX/Options.php
+++ b/src/Writer/XLSX/Options.php
@@ -6,9 +6,9 @@ namespace OpenSpout\Writer\XLSX;
 
 use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Writer\Common\AbstractOptions;
+use OpenSpout\Writer\XLSX\Options\HeaderFooter;
 use OpenSpout\Writer\XLSX\Options\PageMargin;
 use OpenSpout\Writer\XLSX\Options\PageSetup;
-use OpenSpout\Writer\XLSX\Options\HeaderFooter;
 
 final class Options extends AbstractOptions
 {

--- a/src/Writer/XLSX/Options/HeaderFooter.php
+++ b/src/Writer/XLSX/Options/HeaderFooter.php
@@ -7,10 +7,10 @@ namespace OpenSpout\Writer\XLSX\Options;
 final class HeaderFooter
 {
     public function __construct(
-        public readonly ?string $oddHeader,
-        public readonly ?string $oddFooter,
-        public readonly ?string $evenHeader,
-        public readonly ?string $evenFooter,
+        public readonly ?string $oddHeader = null,
+        public readonly ?string $oddFooter = null,
+        public readonly ?string $evenHeader = null,
+        public readonly ?string $evenFooter = null,
         public readonly bool $differentOddEven = false,
     ) {}
 }

--- a/src/Writer/XLSX/Options/HeaderFooter.php
+++ b/src/Writer/XLSX/Options/HeaderFooter.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSpout\Writer\XLSX\Options;
+
+final class HeaderFooter
+{
+    public function __construct(
+        public readonly ?string $oddHeader,
+        public readonly ?string $oddFooter,
+        public readonly ?string $evenHeader,
+        public readonly ?string $evenFooter,
+        public readonly bool $differentOddEven = false,
+    ) {}
+}

--- a/src/Writer/XLSX/Options/PageSetup.php
+++ b/src/Writer/XLSX/Options/PageSetup.php
@@ -9,5 +9,7 @@ final class PageSetup
     public function __construct(
         public readonly ?PageOrientation $pageOrientation,
         public readonly ?PaperSize $paperSize,
+        public ?int $fitToHeight = null,
+        public ?int $fitToWidth = null,
     ) {}
 }

--- a/src/Writer/XLSX/Options/PageSetup.php
+++ b/src/Writer/XLSX/Options/PageSetup.php
@@ -14,7 +14,7 @@ final class PageSetup
         public readonly ?int $fitToHeight = null,
         public readonly ?int $fitToWidth = null,
     ) {
-        if(isset($fitToHeight) || isset($fitToWidth)) {
+        if (isset($fitToHeight) || isset($fitToWidth)) {
             $this->fitToPage = true;
         }
     }

--- a/src/Writer/XLSX/Options/PageSetup.php
+++ b/src/Writer/XLSX/Options/PageSetup.php
@@ -11,8 +11,8 @@ final class PageSetup
     public function __construct(
         public readonly ?PageOrientation $pageOrientation,
         public readonly ?PaperSize $paperSize,
-        public ?int $fitToHeight = null,
-        public ?int $fitToWidth = null,
+        public readonly ?int $fitToHeight = null,
+        public readonly ?int $fitToWidth = null,
     ) {
         if(isset($fitToHeight) || isset($fitToWidth)) {
             $this->fitToPage = true;

--- a/src/Writer/XLSX/Options/PageSetup.php
+++ b/src/Writer/XLSX/Options/PageSetup.php
@@ -6,7 +6,7 @@ namespace OpenSpout\Writer\XLSX\Options;
 
 final class PageSetup
 {
-    public bool $fitToPage = false;
+    public readonly bool $fitToPage;
 
     public function __construct(
         public readonly ?PageOrientation $pageOrientation,
@@ -14,8 +14,6 @@ final class PageSetup
         public readonly ?int $fitToHeight = null,
         public readonly ?int $fitToWidth = null,
     ) {
-        if (isset($fitToHeight) || isset($fitToWidth)) {
-            $this->fitToPage = true;
-        }
+        $this->fitToPage = null !== $fitToHeight || null !== $fitToWidth;
     }
 }

--- a/src/Writer/XLSX/Options/PageSetup.php
+++ b/src/Writer/XLSX/Options/PageSetup.php
@@ -6,7 +6,7 @@ namespace OpenSpout\Writer\XLSX\Options;
 
 final class PageSetup
 {
-    public bool $fitToPage = false;
+    public readonly bool $fitToPage = false;
 
     public function __construct(
         public readonly ?PageOrientation $pageOrientation,

--- a/src/Writer/XLSX/Options/PageSetup.php
+++ b/src/Writer/XLSX/Options/PageSetup.php
@@ -6,7 +6,7 @@ namespace OpenSpout\Writer\XLSX\Options;
 
 final class PageSetup
 {
-    public readonly bool $fitToPage = false;
+    public bool $fitToPage = false;
 
     public function __construct(
         public readonly ?PageOrientation $pageOrientation,

--- a/src/Writer/XLSX/Options/PageSetup.php
+++ b/src/Writer/XLSX/Options/PageSetup.php
@@ -6,10 +6,16 @@ namespace OpenSpout\Writer\XLSX\Options;
 
 final class PageSetup
 {
+    public bool $fitToPage = false;
+
     public function __construct(
         public readonly ?PageOrientation $pageOrientation,
         public readonly ?PaperSize $paperSize,
         public ?int $fitToHeight = null,
         public ?int $fitToWidth = null,
-    ) {}
+    ) {
+        if(isset($fitToHeight) || isset($fitToWidth)) {
+            $this->fitToPage = true;
+        }
+    }
 }

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -929,7 +929,8 @@ final class WriterTest extends TestCase
         $xmlContents = file_get_contents('zip://'.$pathToSheetFile);
 
         self::assertNotFalse($xmlContents);
-        self::assertStringContainsString('<sheetPr><pageSetUpPr fitToPage="1"/></sheetPr><pageSetup orientation="landscape" paperSize="9" fitToHeight="0" fitToWidth="1"/>', $xmlContents);
+        self::assertStringContainsString('<sheetPr><pageSetUpPr fitToPage="true"/></sheetPr>', $xmlContents);
+        self::assertStringContainsString('<pageSetup orientation="landscape" paperSize="9" fitToHeight="0" fitToWidth="1"/>', $xmlContents);
     }
 
     public function testAddHeaderFooterDifferentOddEven(): void

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -903,7 +903,7 @@ final class WriterTest extends TestCase
 
         self::assertNotFalse($xmlContents);
         self::assertStringContainsString('<pageMargins top="1" right="2" bottom="3" left="4" header="5" footer="6"/>', $xmlContents);
-        self::assertStringContainsString('<pageSetup orientation="landscape" paperSize="9" fitToHeight="0" fitToWidth="1"/>', $xmlContents);
+        self::assertStringContainsString('<sheetPr><pageSetUpPr fitToPage="1"/></sheetPr><pageSetup orientation="landscape" paperSize="9" fitToHeight="0" fitToWidth="1"/>', $xmlContents);
     }
 
     public function testAddHeaderFooter(): void

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -903,7 +903,7 @@ final class WriterTest extends TestCase
         self::assertStringContainsString('<pageMargins top="1" right="2" bottom="3" left="4" header="5" footer="6"/>', $xmlContents);
     }
 
-    public function testAddFitToPage(): void
+    public function testAddfitToPageWithTwoArgs(): void
     {
         $fileName = 'test_fit_to_page.xlsx';
         $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
@@ -931,6 +931,35 @@ final class WriterTest extends TestCase
         self::assertNotFalse($xmlContents);
         self::assertStringContainsString('<sheetPr><pageSetUpPr fitToPage="true"/></sheetPr>', $xmlContents);
         self::assertStringContainsString('<pageSetup orientation="landscape" paperSize="9" fitToHeight="0" fitToWidth="1"/>', $xmlContents);
+    }
+
+    public function testAddfitToPageWithOneArgs(): void
+    {
+        $fileName = 'test_fit_to_page.xlsx';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+        $options = new Options();
+        $options->setTempFolder((new TestUsingResource())->getTempFolderPath());
+
+        $options->setPageSetup(new PageSetup(
+            PageOrientation::LANDSCAPE,
+            PaperSize::A4,
+            1,
+        ));
+
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+
+        $row = new Row([Cell::fromValue('something'), Cell::fromValue('else')]);
+        $writer->addRow($row);
+        $writer->close();
+
+        // Now test if the resources contain what we need
+        $pathToSheetFile = $resourcePath.'#xl/worksheets/sheet1.xml';
+        $xmlContents = file_get_contents('zip://'.$pathToSheetFile);
+
+        self::assertNotFalse($xmlContents);
+        self::assertStringContainsString('<sheetPr><pageSetUpPr fitToPage="true"/></sheetPr>', $xmlContents);
+        self::assertStringContainsString('<pageSetup orientation="landscape" paperSize="9" fitToHeight="1"/>', $xmlContents);
     }
 
     public function testAddHeaderFooterDifferentOddEven(): void
@@ -966,6 +995,41 @@ final class WriterTest extends TestCase
             '<oddFooter>oddFooter</oddFooter>'.
             '<evenHeader>evenHeader</evenHeader>'.
             '<evenFooter>evenFooter</evenFooter>'.
+            '</headerFooter>',
+            $xmlContents
+        );
+    }
+
+    public function testAddHeaderFooterDifferentOddEvenWithoutArgument(): void
+    {
+        $fileName = 'test_header_footer.xlsx';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+        $options = new Options();
+        $options->setTempFolder((new TestUsingResource())->getTempFolderPath());
+
+        $options->setHeaderFooter(new HeaderFooter(
+            'oddHeader',
+            'oddFooter',
+            'evenHeader',
+            'evenFooter',
+        ));
+
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+
+        $row = new Row([Cell::fromValue('something'), Cell::fromValue('else')]);
+        $writer->addRow($row);
+        $writer->close();
+
+        // Now test if the resources contain what we need
+        $pathToSheetFile = $resourcePath.'#xl/worksheets/sheet1.xml';
+        $xmlContents = file_get_contents('zip://'.$pathToSheetFile);
+
+        self::assertNotFalse($xmlContents);
+        self::assertStringContainsString(
+            '<headerFooter>'.
+            '<oddHeader>oddHeader</oddHeader>'.
+            '<oddFooter>oddFooter</oddFooter>'.
             '</headerFooter>',
             $xmlContents
         );
@@ -1028,6 +1092,37 @@ final class WriterTest extends TestCase
         self::assertNotFalse($xmlContents);
         self::assertStringContainsString(
             '<definedNames><definedName name="_xlnm.Print_Titles" localSheetId="0">Sheet1!$1:$1</definedName></definedNames>',
+            $xmlContents
+        );
+    }
+
+    public function testAddPrintTitleRowsNotOverwriteOtherDefinedName(): void
+    {
+        $fileName = 'test_print_title_rows_not_overwrite_other_defined_name.xlsx';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+        $options = new Options();
+        $options->setTempFolder((new TestUsingResource())->getTempFolderPath());
+
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+
+        $sheet = $writer->getCurrentSheet();
+        $autoFilter = new AutoFilter(0, 1, 3, 3);
+        $sheet->setAutoFilter($autoFilter);
+        $sheet->setPrintTitleRows('$1:$1');
+        $writer->close();
+
+        // Now test if the resources contain what we need
+        $pathToBookFile = $resourcePath.'#xl/workbook.xml';
+        $xmlContents = file_get_contents('zip://'.$pathToBookFile);
+
+        self::assertNotFalse($xmlContents);
+        self::assertStringContainsString(
+            '<definedName function="false" hidden="true" localSheetId="0" name="_xlnm._FilterDatabase" vbProcedure="false">',
+            $xmlContents
+        );
+        self::assertStringContainsString(
+            '<definedName name="_xlnm.Print_Titles" localSheetId="0">Sheet1!$1:$1</definedName>',
             $xmlContents
         );
     }

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -961,12 +961,13 @@ final class WriterTest extends TestCase
 
         self::assertNotFalse($xmlContents);
         self::assertStringContainsString(
-            '<headerFooter differentOddEven="1">' .
-            '<oddHeader>oddHeader</oddHeader>' .
-            '<oddFooter>oddFooter</oddFooter>' .
-            '<evenHeader>evenHeader</evenHeader>' .
-            '<evenFooter>evenFooter</evenFooter>' .
-            '</headerFooter>', $xmlContents
+            '<headerFooter differentOddEven="1">'.
+            '<oddHeader>oddHeader</oddHeader>'.
+            '<oddFooter>oddFooter</oddFooter>'.
+            '<evenHeader>evenHeader</evenHeader>'.
+            '<evenFooter>evenFooter</evenFooter>'.
+            '</headerFooter>',
+            $xmlContents
         );
     }
 
@@ -998,10 +999,11 @@ final class WriterTest extends TestCase
 
         self::assertNotFalse($xmlContents);
         self::assertStringContainsString(
-            '<headerFooter>' .
-            '<oddHeader>oddHeader</oddHeader>' .
-            '<oddFooter>oddFooter</oddFooter>' .
-            '</headerFooter>', $xmlContents
+            '<headerFooter>'.
+            '<oddHeader>oddHeader</oddHeader>'.
+            '<oddFooter>oddFooter</oddFooter>'.
+            '</headerFooter>',
+            $xmlContents
         );
     }
 
@@ -1025,7 +1027,8 @@ final class WriterTest extends TestCase
 
         self::assertNotFalse($xmlContents);
         self::assertStringContainsString(
-            '<definedNames><definedName name="_xlnm.Print_Titles" localSheetId="0">Sheet1!$1:$1</definedName></definedNames>', $xmlContents
+            '<definedNames><definedName name="_xlnm.Print_Titles" localSheetId="0">Sheet1!$1:$1</definedName></definedNames>',
+            $xmlContents
         );
     }
 

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -906,7 +906,7 @@ final class WriterTest extends TestCase
         self::assertStringContainsString('<sheetPr><pageSetUpPr fitToPage="1"/></sheetPr><pageSetup orientation="landscape" paperSize="9" fitToHeight="0" fitToWidth="1"/>', $xmlContents);
     }
 
-    public function testAddHeaderFooter(): void
+    public function testAddHeaderFooterDifferentOddEven(): void
     {
         $fileName = 'test_header_footer.xlsx';
         $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
@@ -939,6 +939,41 @@ final class WriterTest extends TestCase
             '<oddFooter>oddFooter</oddFooter>' .
             '<evenHeader>evenHeader</evenHeader>' .
             '<evenFooter>evenFooter</evenFooter>' .
+            '</headerFooter>', $xmlContents
+        );
+    }
+
+    public function testAddHeaderFooterSameOddEven(): void
+    {
+        $fileName = 'test_header_footer.xlsx';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+        $options = new Options();
+        $options->setTempFolder((new TestUsingResource())->getTempFolderPath());
+
+        $options->setHeaderFooter(new HeaderFooter(
+            'oddHeader',
+            'oddFooter',
+            'evenHeader',
+            null,
+            false
+        ));
+
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+
+        $row = new Row([Cell::fromValue('something'), Cell::fromValue('else')]);
+        $writer->addRow($row);
+        $writer->close();
+
+        // Now test if the resources contain what we need
+        $pathToSheetFile = $resourcePath.'#xl/worksheets/sheet1.xml';
+        $xmlContents = file_get_contents('zip://'.$pathToSheetFile);
+
+        self::assertNotFalse($xmlContents);
+        self::assertStringContainsString(
+            '<headerFooter>' .
+            '<oddHeader>oddHeader</oddHeader>' .
+            '<oddFooter>oddFooter</oddFooter>' .
             '</headerFooter>', $xmlContents
         );
     }

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -1004,6 +1004,30 @@ final class WriterTest extends TestCase
         );
     }
 
+    public function testAddPrintTitleRows(): void
+    {
+        $fileName = 'test_print_title_rows.xlsx';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+        $options = new Options();
+        $options->setTempFolder((new TestUsingResource())->getTempFolderPath());
+
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+
+        $sheet = $writer->getCurrentSheet();
+        $sheet->setPrintTitleRows('$1:$1');
+        $writer->close();
+
+        // Now test if the resources contain what we need
+        $pathToBookFile = $resourcePath.'#xl/workbook.xml';
+        $xmlContents = file_get_contents('zip://'.$pathToBookFile);
+
+        self::assertNotFalse($xmlContents);
+        self::assertStringContainsString(
+            '<definedNames><definedName name="_xlnm.Print_Titles" localSheetId="0">Sheet1!$1:$1</definedName></definedNames>', $xmlContents
+        );
+    }
+
     public function testWriteDateInterval(): void
     {
         $fileName = 'test_date_interval.xlsx';

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -885,8 +885,6 @@ final class WriterTest extends TestCase
         $options->setPageSetup(new PageSetup(
             PageOrientation::LANDSCAPE,
             PaperSize::A4,
-            0,
-            1,
         ));
         $options->setPageMargin(new PageMargin(1, 2, 3, 4, 5, 6));
 
@@ -903,6 +901,34 @@ final class WriterTest extends TestCase
 
         self::assertNotFalse($xmlContents);
         self::assertStringContainsString('<pageMargins top="1" right="2" bottom="3" left="4" header="5" footer="6"/>', $xmlContents);
+    }
+
+    public function testAddFitToPage(): void
+    {
+        $fileName = 'test_fit_to_page.xlsx';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+        $options = new Options();
+        $options->setTempFolder((new TestUsingResource())->getTempFolderPath());
+
+        $options->setPageSetup(new PageSetup(
+            PageOrientation::LANDSCAPE,
+            PaperSize::A4,
+            0,
+            1
+        ));
+
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+
+        $row = new Row([Cell::fromValue('something'), Cell::fromValue('else')]);
+        $writer->addRow($row);
+        $writer->close();
+
+        // Now test if the resources contain what we need
+        $pathToSheetFile = $resourcePath.'#xl/worksheets/sheet1.xml';
+        $xmlContents = file_get_contents('zip://'.$pathToSheetFile);
+
+        self::assertNotFalse($xmlContents);
         self::assertStringContainsString('<sheetPr><pageSetUpPr fitToPage="1"/></sheetPr><pageSetup orientation="landscape" paperSize="9" fitToHeight="0" fitToWidth="1"/>', $xmlContents);
     }
 


### PR DESCRIPTION
## Add support for headerFooter, fitToHeight/Width, printTitleRows (xlsx only)

### headerFooter

Header and footer can be set via Options::setHeaderFooter()
```
$options = new Options();
$options->setHeaderFooter(new HeaderFooter(
    'oddHeader',
    'oddFooter',
    'evenHeader',
    'evenFooter',
    true  // differentOddEven, default value is false
));
```
### fitToHeight/Width

Add new arguments for fitToHeight and fitToWidth to the PageSetup constructor.
```
$options = new Options();
$options->setPageSetup(new PageSetup(
    PageOrientation::LANDSCAPE,
    PaperSize::A4,
    0, // ?int fitToHeight
    1  // ?int fitToWidth
));
```

### printTitleRows 

Print title rows can be set at the sheet level for XLSX writers.

```
$writer = new Writer($options);
$sheet = $writer->getCurrentSheet();
$sheet->setPrintTitleRows('$2:$2');
```

### Examples (preview images)

![image1](https://github.com/openspout/openspout/assets/59961751/08a8cdd0-5c77-4dd0-ba9c-1d0a60c5d2bc)
![image2](https://github.com/openspout/openspout/assets/59961751/fa91f907-c8ee-4493-8037-19385b293d95)
![image3](https://github.com/openspout/openspout/assets/59961751/3f8304ef-f4c6-4a00-a628-1010c525e087)
