### PR TITLE
Enhance Row::fromValues can accept Cell object (StringCell)

### DIFF
--- a/src/Common/Entity/Row.php
+++ b/src/Common/Entity/Row.php
@@ -6,6 +6,7 @@ namespace OpenSpout\Common\Entity;
 
 use DateInterval;
 use DateTimeInterface;
+use OpenSpout\Common\Entity\Cell\StringCell;
 use OpenSpout\Common\Entity\Style\Style;
 
 final class Row
@@ -37,11 +38,14 @@ final class Row
     }
 
     /**
-     * @param list<null|bool|DateInterval|DateTimeInterface|float|int|string> $cellValues
+     * @param list<null|bool|DateInterval|DateTimeInterface|float|int|string|StringCell> $cellValues
      */
     public static function fromValues(array $cellValues = [], ?Style $rowStyle = null): self
     {
-        $cells = array_map(static function (null|bool|DateInterval|DateTimeInterface|float|int|string $cellValue): Cell {
+        $cells = array_map(static function (null|bool|DateInterval|DateTimeInterface|float|int|string|StringCell $cellValue): Cell {
+            if ($cellValue instanceof StringCell) {
+                return $cellValue;
+            }
             return Cell::fromValue($cellValue);
         }, $cellValues);
 


### PR DESCRIPTION
I was wondering if we could accept only for specific cell with style using Cell::fromValue using Row::fromValues as following example data:

$values = [
       "string",
       "string",
       Cell::fromValue("string", Style)
];

Row::fromValues($values);

I was concerning about if we have a huge number of data, it would be unnecessary to put every single data with function Cell::fromValue if the data using default style.
