### PR TITLE
Create row from values with per cell styling

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -83,6 +83,12 @@ $values = ['Carl', 'is', 'great!'];
 $rowFromValues = Row::fromValues($values);
 $writer->addRow($rowFromValues);
 
+/** Shortcut: add a row from an array of values with cell-specific formatting */
+$values = ['Today', 'is', new DateTime('2024-05-10 10:00:00.0')];
+$styles = [2 => (new Style())->setFormat('mm/dd/yyyy')]
+$rowFromValuesWithStyles = Row::fromValuesWithStyles($values, columnStyles: $styles);
+$writer->addRow($rowFromValuesWithStyles);
+
 $writer->close();
 /**
  * in case of streaming data directly to the browser with $writer->openToBrowser() ensure

--- a/src/Common/Entity/Row.php
+++ b/src/Common/Entity/Row.php
@@ -38,9 +38,21 @@ final class Row
 
     /**
      * @param list<null|bool|DateInterval|DateTimeInterface|float|int|string> $cellValues
-     * @param Style[]                                                         $columnStyles
      */
-    public static function fromValues(array $cellValues = [], ?Style $rowStyle = null, array $columnStyles = []): self
+    public static function fromValues(array $cellValues = [], ?Style $rowStyle = null): self
+    {
+        $cells = array_map(static function (null|bool|DateInterval|DateTimeInterface|float|int|string $cellValue): Cell {
+            return Cell::fromValue($cellValue);
+        }, $cellValues);
+
+        return new self($cells, $rowStyle);
+    }
+
+    /**
+     * @param array<array-key, null|bool|DateInterval|DateTimeInterface|float|int|string> $cellValues
+     * @param array<array-key, Style>                                                     $columnStyles
+     */
+    public static function fromValuesWithStyles(array $cellValues = [], ?Style $rowStyle = null, array $columnStyles = []): self
     {
         $cells = array_map(static function (null|bool|DateInterval|DateTimeInterface|float|int|string $cellValue, int|string $key) use ($columnStyles): Cell {
             return Cell::fromValue($cellValue, $columnStyles[$key] ?? null);

--- a/src/Common/Entity/Row.php
+++ b/src/Common/Entity/Row.php
@@ -38,12 +38,13 @@ final class Row
 
     /**
      * @param list<null|bool|DateInterval|DateTimeInterface|float|int|string> $cellValues
+     * @param Style[]                                                         $columnStyles
      */
-    public static function fromValues(array $cellValues = [], ?Style $rowStyle = null): self
+    public static function fromValues(array $cellValues = [], ?Style $rowStyle = null, array $columnStyles = []): self
     {
-        $cells = array_map(static function (null|bool|DateInterval|DateTimeInterface|float|int|string $cellValue): Cell {
-            return Cell::fromValue($cellValue);
-        }, $cellValues);
+        $cells = array_map(static function (null|bool|DateInterval|DateTimeInterface|float|int|string $cellValue, int|string $key) use ($columnStyles): Cell {
+            return Cell::fromValue($cellValue, $columnStyles[$key] ?? null);
+        }, $cellValues, array_keys($cellValues));
 
         return new self($cells, $rowStyle);
     }

--- a/tests/Common/Entity/RowTest.php
+++ b/tests/Common/Entity/RowTest.php
@@ -6,6 +6,7 @@ namespace OpenSpout\Common\Entity;
 
 use DateInterval;
 use DateTime;
+use OpenSpout\Common\Entity\Style\Style;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -90,6 +91,27 @@ final class RowTest extends TestCase
         ];
 
         self::assertSame($supportedValueTypes, Row::fromValues($supportedValueTypes)->toArray());
+    }
+
+    public function testRowFromValuesWithStylesHasCorrectStyles(): void
+    {
+        $cellValues = [
+            new DateTime('2024-05-10 10:00:00.0'),
+            9.18,
+            10,
+        ];
+
+        /** @var array<int, Style> $columnStyles */
+        $columnStyles = [
+            0 => (new Style())->setFormat('mm/dd/yyyy'),
+            1 => (new Style())->setFormat('0.00'),
+            2 => (new Style())->setFormat('0'),
+        ];
+
+        $row = Row::fromValuesWithStyles($cellValues, columnStyles: $columnStyles);
+        foreach ($columnStyles as $index => $style) {
+            self::assertEquals($style->getFormat(), $row->getCellAtIndex($index)->getStyle()->getFormat());
+        }
     }
 
     /**


### PR DESCRIPTION
Allows to specify an array with styles per column when calling `Row::fromValues`.
This could for instance be used to mark certain cells as date:

```php
  Row::fromValues(
    cellValues: $values, 
    columnStyles: [
      0 => (new Style[])->setFormat('dd-mm-yyyy'),
    ]
  )
```