### PR TITLE
Raise exception when file is missing and `realpath` returns `false`

### DIFF
--- a/src/Reader/Wrapper/XMLReader.php
+++ b/src/Reader/Wrapper/XMLReader.php
@@ -58,7 +58,7 @@ final class XMLReader extends \XMLReader
             throw new IOException("Could not open {$zipFilePath} for reading! File does not exist.");
         }
 
-        return self::ZIP_WRAPPER. $realpath .'#'.$fileInsideZipPathWithoutLeadingSlash;
+        return self::ZIP_WRAPPER.$realpath.'#'.$fileInsideZipPathWithoutLeadingSlash;
     }
 
     /**

--- a/src/Reader/Wrapper/XMLReader.php
+++ b/src/Reader/Wrapper/XMLReader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenSpout\Reader\Wrapper;
 
+use OpenSpout\Common\Exception\IOException;
 use OpenSpout\Reader\Exception\XMLProcessingException;
 use ZipArchive;
 
@@ -52,7 +53,12 @@ final class XMLReader extends \XMLReader
         // The file path should not start with a '/', otherwise it won't be found
         $fileInsideZipPathWithoutLeadingSlash = ltrim($fileInsideZipPath, '/');
 
-        return self::ZIP_WRAPPER.realpath($zipFilePath).'#'.$fileInsideZipPathWithoutLeadingSlash;
+        $realpath = realpath($zipFilePath);
+        if (false === $realpath) {
+            throw new IOException("Could not open {$zipFilePath} for reading! File does not exist.");
+        }
+
+        return self::ZIP_WRAPPER. $realpath .'#'.$fileInsideZipPathWithoutLeadingSlash;
     }
 
     /**


### PR DESCRIPTION
This could occur when reading from tmp-file which is closed somewhere in the middle

fixes #238 