### PR TITLE
allow optional flock of file when writing

### DIFF
--- a/src/Writer/CSV/Options.php
+++ b/src/Writer/CSV/Options.php
@@ -9,6 +9,7 @@ final class Options
     public string $FIELD_DELIMITER = ',';
     public string $FIELD_ENCLOSURE = '"';
     public bool $SHOULD_ADD_BOM = true;
+    public bool $SHOULD_LOCK_FILE_FOR_WRITING = false;
 
     /** @var positive-int */
     public int $FLUSH_THRESHOLD = 500;

--- a/src/Writer/CSV/Writer.php
+++ b/src/Writer/CSV/Writer.php
@@ -22,6 +22,8 @@ final class Writer extends AbstractWriter
     public function __construct(?Options $options = null)
     {
         $this->options = $options ?? new Options();
+
+        $this->shouldLockFileForWriting = $this->options->SHOULD_LOCK_FILE_FOR_WRITING;
     }
 
     public function getOptions(): Options

--- a/src/Writer/Common/AbstractOptions.php
+++ b/src/Writer/Common/AbstractOptions.php
@@ -13,6 +13,7 @@ abstract class AbstractOptions
 
     public Style $DEFAULT_ROW_STYLE;
     public bool $SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY = true;
+    public bool $SHOULD_LOCK_FILE_FOR_WRITING = false;
     public ?float $DEFAULT_COLUMN_WIDTH = null;
     public ?float $DEFAULT_ROW_HEIGHT = null;
 

--- a/src/Writer/ODS/Writer.php
+++ b/src/Writer/ODS/Writer.php
@@ -24,6 +24,8 @@ final class Writer extends AbstractWriterMultiSheets
     public function __construct(?Options $options = null)
     {
         $this->options = $options ?? new Options();
+
+        $this->shouldLockFileForWriting = $this->options->SHOULD_LOCK_FILE_FOR_WRITING;
     }
 
     public function getOptions(): Options

--- a/src/Writer/XLSX/Writer.php
+++ b/src/Writer/XLSX/Writer.php
@@ -28,6 +28,8 @@ final class Writer extends AbstractWriterMultiSheets
     public function __construct(?Options $options = null)
     {
         $this->options = $options ?? new Options();
+
+        $this->shouldLockFileForWriting = $this->options->SHOULD_LOCK_FILE_FOR_WRITING;
     }
 
     public function getOptions(): Options


### PR DESCRIPTION
https://github.com/openspout/openspout/issues/252

The simplest way it seems is to call `flock($resource, LOCK_EX)` in `AbstractWriter::openToFile`,  then `flock($this->filePointer, LOCK_UN)` in `AbstractWriter::close` . However the abstract class does not have an options property.

I've added `public bool $shouldLockFileForWriting = false;` to the `AbstractWriter`, then set this property based on `Options` in the `Writer`s' constructors. Of course the default is false so it won't change the behavior without first setting the option to `true`.

I'm not sure if this is how the maintainers would want this implemented, so I'm opening as a draft to start.  Open to suggestions and review.

Example usage:

```php

$options = new OpenSpout\Writer\CSV\Options();

$options->SHOULD_LOCK_FILE_FOR_WRITING = true;

$writer = new OpenSpout\Writer\CSV\Writer($options);
```