### PR TITLE
Fix: always write sheet `dimension` tag even when there's no autofilter

### DIFF
--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -321,24 +321,23 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
             fwrite($worksheetFilePointer, self::SHEET_XML_FILE_HEADER);
 
             // AutoFilter tags
-            $range = '';
             if (null !== $autofilter = $sheet->getAutoFilter()) {
-                $range = sprintf(
-                    '%s%s:%s%s',
-                    CellHelper::getColumnLettersFromColumnIndex($autofilter->fromColumnIndex),
-                    $autofilter->fromRow,
-                    CellHelper::getColumnLettersFromColumnIndex($autofilter->toColumnIndex),
-                    $autofilter->toRow
-                );
                 if (isset($pageSetup) && $pageSetup->fitToPage) {
                     fwrite($worksheetFilePointer, '<sheetPr filterMode="false"><pageSetUpPr fitToPage="true"/></sheetPr>');
                 } else {
                     fwrite($worksheetFilePointer, '<sheetPr filterMode="false"><pageSetUpPr fitToPage="false"/></sheetPr>');
                 }
-                fwrite($worksheetFilePointer, sprintf('<dimension ref="%s"/>', $range));
             } elseif (isset($pageSetup) && $pageSetup->fitToPage) {
                 fwrite($worksheetFilePointer, '<sheetPr><pageSetUpPr fitToPage="true"/></sheetPr>');
             }
+            $sheetRange = sprintf(
+                '%s%s:%s%s',
+                CellHelper::getColumnLettersFromColumnIndex(0),
+                1,
+                CellHelper::getColumnLettersFromColumnIndex($worksheet->getMaxNumColumns() - 1),
+                $worksheet->getLastWrittenRowIndex()
+            );
+            fwrite($worksheetFilePointer, sprintf('<dimension ref="%s"/>', $sheetRange));
             if (null !== ($sheetView = $sheet->getSheetView())) {
                 fwrite($worksheetFilePointer, '<sheetViews>'.$sheetView->getXml().'</sheetViews>');
             }
@@ -351,8 +350,15 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
             fwrite($worksheetFilePointer, '</sheetData>');
 
             // AutoFilter tag
-            if ('' !== $range) {
-                fwrite($worksheetFilePointer, sprintf('<autoFilter ref="%s"/>', $range));
+            if (null !== $autofilter) {
+                $autoFilterRange = sprintf(
+                    '%s%s:%s%s',
+                    CellHelper::getColumnLettersFromColumnIndex($autofilter->fromColumnIndex),
+                    $autofilter->fromRow,
+                    CellHelper::getColumnLettersFromColumnIndex($autofilter->toColumnIndex),
+                    $autofilter->toRow
+                );
+                fwrite($worksheetFilePointer, sprintf('<autoFilter ref="%s"/>', $autoFilterRange));
             }
 
             // create nodes for merge cells

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -657,6 +657,28 @@ final class WriterTest extends TestCase
         self::assertSame(6, $writer->getWrittenRowCount());
     }
 
+    public function testCloseShouldAddDimensionTag(): void
+    {
+        $fileName = 'test_close_should_add_dimension_tag.xlsx';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+
+        $options = new Options();
+        $options->setTempFolder((new TestUsingResource())->getTempFolderPath());
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+        $writer->addRow(Row::fromValues(['csv-1', null]));
+        $writer->addRow(Row::fromValues(['csv-2-1', 'csv-2-2']));
+        $writer->addRow(Row::fromValues([null, 'csv-3']));
+        $writer->close();
+
+        $xmlReader = $this->getXmlReaderForSheetFromXmlFile($fileName, '1');
+        $xmlReader->readUntilNodeFound('dimension');
+        self::assertSame('dimension', $xmlReader->getCurrentNodeName(), 'Sheet does not have dimension tag');
+        $DOMNode = $xmlReader->expand();
+        self::assertInstanceOf(DOMElement::class, $DOMNode);
+        self::assertSame('A1:B3', $DOMNode->getAttribute('ref'), 'Merge ref for dimension range is not valid.');
+    }
+
     public function testCloseShouldAddAutofilterTag(): void
     {
         $fileName = 'test_close_should_add_autofilter_tag.xlsx';


### PR DESCRIPTION
The `dimension` tag for each sheet tells the cell range that sheet data is using, but it has no relation with autofilter.

The autofilter tag has its own cell range.

Other libraries rely on the `dimension` tag to get the cell range fast, otherwise they have to parse whole file, and can be slow on huge files.

Added a simple test.