### PR TITLE
Implement collapsible columns for XLSX

### DIFF
--- a/src/Writer/Common/ColumnAttributes.php
+++ b/src/Writer/Common/ColumnAttributes.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSpout\Writer\Common;
+
+/**
+ * @internal
+ */
+final class ColumnAttributes
+{
+    public function __construct(
+        public readonly ?int $outlineLevel = null,
+        public readonly bool $collapsed = false,
+        public readonly bool $hidden = false
+    ) {
+    }
+
+    public function getOutlineLevel(): ?int
+    {
+        return $this->outlineLevel;
+    }
+
+    public function setOutlineLevel(?int $outlineLevel): void
+    {
+        $this->outlineLevel = $outlineLevel;
+    }
+
+    public function isCollapsed(): bool
+    {
+        return $this->collapsed;
+    }
+
+    public function setCollapsed(bool $collapsed): void
+    {
+        $this->collapsed = $collapsed;
+    }
+
+    public function isHidden(): bool
+    {
+        return $this->hidden;
+    }
+
+    public function setHidden(bool $hidden): void
+    {
+        $this->hidden = $hidden;
+    }
+
+    public function isEmpty(): bool
+    {
+        return null === $this->getOutlineLevel()
+            && false === $this->isCollapsed()
+            && false === $this->isHidden();
+    }
+}

--- a/src/Writer/Common/ColumnWidth.php
+++ b/src/Writer/Common/ColumnWidth.php
@@ -9,6 +9,8 @@ namespace OpenSpout\Writer\Common;
  */
 final class ColumnWidth
 {
+    private ColumnAttributes $columnAttributes;
+
     /**
      * @param positive-int $start
      * @param positive-int $end
@@ -17,5 +19,17 @@ final class ColumnWidth
         public readonly int $start,
         public readonly int $end,
         public readonly float $width,
-    ) {}
+    ) {
+        $this->columnAttributes = new ColumnAttributes();
+    }
+
+    public function setColumnAttributes(ColumnAttributes $columnAttributes) : ColumnAttributes {
+        $this->columnAttributes = $columnAttributes;
+
+        return $this->columnAttributes;
+    }
+
+    public function getColumnAttributes() : ColumnAttributes {
+        return $this->columnAttributes;
+    }
 }

--- a/src/Writer/Common/Entity/Sheet.php
+++ b/src/Writer/Common/Entity/Sheet.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenSpout\Writer\Common\Entity;
 
 use OpenSpout\Writer\AutoFilter;
+use OpenSpout\Writer\Common\ColumnAttributes;
 use OpenSpout\Writer\Common\ColumnWidth;
 use OpenSpout\Writer\Common\Manager\SheetManager;
 use OpenSpout\Writer\Exception\InvalidSheetNameException;
@@ -44,6 +45,9 @@ final class Sheet
 
     /** @var string rows to repeat at top */
     private ?string $printTitleRows = null;
+
+    /** @var ColumnAttributes[] Array to store attributes for each column */
+    private array $columnAttributes = [];
 
     /**
      * @param 0|positive-int $sheetIndex           Index of the sheet, based on order in the workbook (zero-based)
@@ -197,7 +201,12 @@ final class Sheet
      */
     public function setColumnWidthForRange(float $width, int $start, int $end): void
     {
-        $this->COLUMN_WIDTHS[] = new ColumnWidth($start, $end, $width);
+        $columnWidth = new ColumnWidth($start, $end, $width);
+        for ($columnIndex = $start; $columnIndex <= $end; $columnIndex++) {
+            $attributes = $this->getColumnAttributes($columnIndex);
+            $columnWidth->setColumnAttributes($attributes);
+        }
+        $this->COLUMN_WIDTHS[] = $columnWidth;  
     }
 
     /**
@@ -218,5 +227,35 @@ final class Sheet
     public function setPrintTitleRows(string $printTitleRows): void
     {
         $this->printTitleRows = $printTitleRows;
+    }
+
+    /**
+     * Set attributes for multiple columns.
+     *
+     * @param int $outlineLevel The outline level to set
+     * @param bool $collapsed Whether the columns should be collapsed
+     * @param bool $hidden Whether the columns should be hidden
+     * @param positive-int ...$columns One or more columns to set the attributes for
+     */
+    public function setColumnAttributes(?int $outlineLevel, bool $collapsed, bool $hidden, int ...$columns): void
+    {
+        foreach ($columns as $columnIndex) {
+            $this->columnAttributes[$columnIndex] = new ColumnAttributes($outlineLevel, $collapsed, $hidden);
+        }
+    }
+
+    /**
+     * Get the attributes for a specific column.
+     *
+     * @param positive-int $columnIndex The column index
+     * @return ColumnAttributes|null The attributes for the column, or null if not set
+     */
+    public function getColumnAttributes(int $columnIndex): ColumnAttributes
+    {
+        if (!isset($this->columnAttributes[$columnIndex])) {
+            $this->columnAttributes[$columnIndex] = new ColumnAttributes();
+        }
+
+        return $this->columnAttributes[$columnIndex];
     }
 }

--- a/tests/Writer/XLSX/SheetTest.php
+++ b/tests/Writer/XLSX/SheetTest.php
@@ -367,6 +367,33 @@ final class SheetTest extends TestCase
         self::assertStringContainsString('<col min="1" max="3" width="100" customWidth="true"', $xmlContents, 'No expected column width definition found in sheet');
     }
 
+    public function testColumnAttributes(): void
+    {
+        $fileName = 'test_column_attributes.xlsx';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+
+        $options = new Options();
+        $options->setTempFolder((new TestUsingResource())->getTempFolderPath());
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+        
+        $writer->addRow(Row::fromValues(['xlsx--11', 'xlsx--12', 'xlsx--13']));
+        $sheet = $writer->getCurrentSheet();
+
+        $sheet->setColumnAttributes(1, false, true, 1, 2, 3);
+        $sheet->setColumnWidthForRange(50.0, 1, 3);
+
+        $writer->close();
+
+        $pathToWorkbookFile = $resourcePath.'#xl/worksheets/sheet1.xml';
+        $xmlContents = file_get_contents('zip://'.$pathToWorkbookFile);
+
+        self::assertNotFalse($xmlContents);
+        self::assertStringContainsString('<cols', $xmlContents, 'No cols tag found in sheet');
+        self::assertStringContainsString('<col min="1" max="3" width="50" customWidth="true" outlineLevel="1" hidden="true"', $xmlContents, 'No expected outline attributes for column width definition found in sheet');
+        self::assertStringContainsString('<col min="3" max="3" width="50" customWidth="true"', $xmlContents, 'No expected empty column found in sheet');
+    }
+
     public function testCanWriteAFormula(): void
     {
         $fileName = 'test_formula.xlsx';


### PR DESCRIPTION
**Overview**
This PR introduces the ability to collapse selected columns in XLSX documents.

![CleanShot 2024-10-04 at 16 05 05](https://github.com/user-attachments/assets/deaaa056-64ab-49a4-bf63-4430ab7b0a8f)

**Usage**
```
$columns = [2, 3];
$sheet->setColumnAttributes(1, false, true, ...$columns);
```
It will group the 2nd and 3rd columns under the 1st outline level.

**Challenges**
I'm still unsure about the best way to implement this and would really appreciate your feedback and suggestions. If you think a different approach might be better, please let me know. I'm open to refactoring it if we can agree on a solid solution.

Initially, I implemented this by adding extra arguments to the `setColumnWidth()` and `setColumnWidthForRange()` methods, but then I realized that this might not be the best idea, as every user would need to update their codebase to adapt to the new method structure.

I considered also on creating extra method(s) like `setOutlineLevel()` and `setCollapsed()` directly in `AbstractOptions` class. However, implementing this may be challenging, because we would need to add options to the existing `ColumnWidth` objects in `$this->COLUMN_WIDTHS`.


**Next Steps**
- [ ] Update the documentation
- [ ] Implement it for `AbstractOptions.php`
- [ ] Add more tests
- [ ] Refactor code to follow all code standards