### PR TITLE
XLSX Protection Bugfix

### DIFF
--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -367,6 +367,10 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
             $this->copyFileContentsToTarget($worksheetFilePath, $worksheetFilePointer);
             fwrite($worksheetFilePointer, '</sheetData>');
 
+            if (null !== $sheet->getSheetProtection()) {
+                fwrite($worksheetFilePointer, $sheet->getSheetProtection()->getXml());
+            }
+
             // AutoFilter tag
             if (null !== $autofilter) {
                 $autoFilterRange = \sprintf(
@@ -407,10 +411,6 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
 
             // Add the legacy drawing for comments
             fwrite($worksheetFilePointer, '<legacyDrawing r:id="rId_comments_vml1"/>');
-
-            if (null !== $sheet->getSheetProtection()) {
-                fwrite($worksheetFilePointer, $sheet->getSheetProtection()->getXml());
-            }
 
             fwrite($worksheetFilePointer, '</worksheet>');
             fclose($worksheetFilePointer);

--- a/src/Writer/XLSX/Options/SheetProtection.php
+++ b/src/Writer/XLSX/Options/SheetProtection.php
@@ -30,7 +30,7 @@ final readonly class SheetProtection
 
     public function getXml(): string
     {
-        return '<sheetProtection'.$this->getSheetViewAttributes().'></sheetProtection>';
+        return '<sheetProtection'.$this->getSheetViewAttributes().'/>';
     }
 
     private function getSheetViewAttributes(): string

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -1349,6 +1349,34 @@ final class WriterTest extends TestCase
         self::assertStringContainsString('<sheetProtection password="83AF" sheet="true" objects="true" scenarios="false" formatCells="false" formatColumns="false" formatRows="true" insertColumns="false" insertRows="true" deleteColumns="true" deleteRows="false" selectLockedCells="true" selectUnlockedCells="false" autoFilter="false" sort="true" hyperlink="false" pivotTables="true"/>', $xmlContents);
     }
 
+    public function testSheetProtectionElementIsCorrectlyPositioned(): void
+    {
+        $fileName = 'test_sheet_protection_setup.xlsx';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+        $options = new Options();
+        $options->setTempFolder((new TestUsingResource())->getTempFolderPath());
+
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+
+        $protection = new SheetProtection(
+            password: 'password',
+        );
+
+        $writer->getCurrentSheet()->setSheetProtection($protection);
+
+        $row = new Row([Cell::fromValue('something'), Cell::fromValue('else')]);
+        $writer->addRow($row);
+        $writer->close();
+
+        // Now test if the resources contain what we need
+        $pathToSheetFile = $resourcePath.'#xl/worksheets/sheet1.xml';
+        $xmlContents = file_get_contents('zip://'.$pathToSheetFile);
+
+        self::assertNotFalse($xmlContents);
+        self::assertStringContainsString('</sheetData><sheetProtection ', $xmlContents);
+    }
+
     public function testSetWorkbookProtection(): void
     {
         $fileName = 'test_set_workbook_protection.xlsx';

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -1346,7 +1346,7 @@ final class WriterTest extends TestCase
         $xmlContents = file_get_contents('zip://'.$pathToSheetFile);
 
         self::assertNotFalse($xmlContents);
-        self::assertStringContainsString('<sheetProtection password="83AF" sheet="true" objects="true" scenarios="false" formatCells="false" formatColumns="false" formatRows="true" insertColumns="false" insertRows="true" deleteColumns="true" deleteRows="false" selectLockedCells="true" selectUnlockedCells="false" autoFilter="false" sort="true" hyperlink="false" pivotTables="true"></sheetProtection>', $xmlContents);
+        self::assertStringContainsString('<sheetProtection password="83AF" sheet="true" objects="true" scenarios="false" formatCells="false" formatColumns="false" formatRows="true" insertColumns="false" insertRows="true" deleteColumns="true" deleteRows="false" selectLockedCells="true" selectUnlockedCells="false" autoFilter="false" sort="true" hyperlink="false" pivotTables="true"/>', $xmlContents);
     }
 
     public function testSetWorkbookProtection(): void


### PR DESCRIPTION
While the current sheets open just fine in LibreOffice, Microsoft Excel fails to open a protected worksheet stating:

> Some parts of this workbook may have been repaired or discarded.

After it does a repair the protected worksheets are empty.

The requirements appear to be that `<sheetProtection/>` is self-closing and that it is directly after `<sheetData/>`