### PR TITLE
Fix: Handle Undefined Style ID in getNumberFormatCode

### DIFF
--- a/src/Reader/XLSX/Manager/StyleManager.php
+++ b/src/Reader/XLSX/Manager/StyleManager.php
@@ -102,6 +102,11 @@ class StyleManager implements StyleManagerInterface
         }
 
         $stylesAttributes = $this->getStylesAttributes();
+
+        if (!isset($stylesAttributes[$styleId])) {
+            return '';
+        }
+
         $styleAttributes = $stylesAttributes[$styleId];
         $numFmtId = $styleAttributes[self::XML_ATTRIBUTE_NUM_FMT_ID];
         \assert(\is_int($numFmtId));

--- a/tests/Reader/XLSX/Manager/StyleManagerTest.php
+++ b/tests/Reader/XLSX/Manager/StyleManagerTest.php
@@ -20,6 +20,14 @@ final class StyleManagerTest extends TestCase
         self::assertFalse($shouldFormatAsDate);
     }
 
+    public function testShouldReturnEmptyNumberFormatCodeForUnknownStyleId(): void
+    {
+        $styleManager = $this->getStyleManagerMock();
+        $numberFormatCode = $styleManager->getNumberFormatCode(0);
+
+        self::assertEmpty($numberFormatCode);
+    }
+
     public function testShouldFormatNumericValueAsDateWhenShouldNotApplyNumberFormat(): void
     {
         $styleManager = $this->getStyleManagerMock([[], ['applyNumberFormat' => false, 'numFmtId' => 14]]);


### PR DESCRIPTION
## Summary
This PR fixes an "Undefined array key" error that occurs in `StyleManager::getNumberFormatCode(int $styleId)`. The issue happens when an unknown `styleId` is passed, causing an access attempt on a non-existent array index.

## Details
When processing an XLSX file, OpenSpout throws an error if the `styleId` does not exist in `$stylesAttributes`:
```
ErrorException: Undefined array key 3 in StyleManager.php:105
```
This occurs because `$stylesAttributes[$styleId]` is accessed without checking if `styleId` exists in the array.

## Fix implementation
Added a guard clause to return an empty string if the `styleId` is not set in `$stylesAttributes`:
```php
if (!isset($stylesAttributes[$styleId])) {
    return '';
}
```

## Test Coverage
Added a test case to verify that an unknown `styleId` returns an empty string instead of throwing an error.

## Impact
- Prevents crashes when processing XLSX files with undefined style references.
- Improves stability when dealing with malformed or unexpected data.