### PR TITLE
Fix: Handle Undefined number format ID in getNumberFormatCode

### DIFF
--- a/src/Reader/XLSX/Manager/StyleManager.php
+++ b/src/Reader/XLSX/Manager/StyleManager.php
@@ -109,6 +109,11 @@ class StyleManager implements StyleManagerInterface
 
         $styleAttributes = $stylesAttributes[$styleId];
         $numFmtId = $styleAttributes[self::XML_ATTRIBUTE_NUM_FMT_ID];
+
+        if (null === $numFmtId) {
+            return '';
+        }
+
         \assert(\is_int($numFmtId));
 
         if ($this->isNumFmtIdBuiltInDateFormat($numFmtId)) {

--- a/tests/Reader/XLSX/Manager/StyleManagerTest.php
+++ b/tests/Reader/XLSX/Manager/StyleManagerTest.php
@@ -28,6 +28,14 @@ final class StyleManagerTest extends TestCase
         self::assertEmpty($numberFormatCode);
     }
 
+    public function testShouldReturnEmptyNumberFormatCodeForNoNumFmtId(): void
+    {
+        $styleManager = $this->getStyleManagerMock([[], ['applyNumberFormat' => null, 'numFmtId' => null]]);
+        $numberFormatCode = $styleManager->getNumberFormatCode(1);
+
+        self::assertEmpty($numberFormatCode);
+    }
+
     public function testShouldFormatNumericValueAsDateWhenShouldNotApplyNumberFormat(): void
     {
         $styleManager = $this->getStyleManagerMock([[], ['applyNumberFormat' => false, 'numFmtId' => 14]]);


### PR DESCRIPTION
Fixes #307 , when style has not defined `numFmtId` as before function `getNumberFormatCode` would crash failing to assert this value as integer.