### PR TITLE
Fix .rels XML relationship type of core-properties

### DIFF
--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -615,7 +615,7 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
     {
         $relationshipsXmlContents = <<<'EOD'
             <Relationship Id="rIdWorkbook" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
-            <Relationship Id="rIdCore" Type="http://schemas.openxmlformats.org/officedocument/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>
+            <Relationship Id="rIdCore" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>
             <Relationship Id="rIdApp" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties" Target="docProps/app.xml"/>
             EOD;
 


### PR DESCRIPTION
Document properties are not visible when set, this fixes that.

Fix .rels XML relationship type of core-properties, see: https://learn.microsoft.com/en-us/office/dev/add-ins/word/create-better-add-ins-for-word-with-office-open-xml#create-your-own-markup-best-practices

Before fix:
![before_fix](https://github.com/user-attachments/assets/9e3c43d6-6de6-4690-bf6a-17ef1b8bbf39)

After fix:
![after_fix](https://github.com/user-attachments/assets/5a00208b-18d6-489c-b2a9-36f490116317)

