### PR TITLE
XLSX Sheet: deprecate `setShowZeroes`, add `setShowZeros`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -2,13 +2,16 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
+
 $config = (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
+    ->setParallelConfig(ParallelConfigFactory::detect())
     ->setRules([
         '@DoctrineAnnotation' => true,
-        '@PHP80Migration' => true,
+        '@PHP83Migration' => true,
         '@PHP80Migration:risky' => true,
-        '@PHPUnit84Migration:risky' => true,
+        '@PHPUnit100Migration:risky' => true,
         '@PhpCsFixer' => true,
         '@PhpCsFixer:risky' => true,
         'comment_to_phpdoc' => false,

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -114,7 +114,7 @@ $sheetView->setZoomScale(150); // And other options
 $sheetView->setShowFormulas(true);
 $sheetView->setShowGridLines(false);
 $sheetView->setShowRowColHeaders(false);
-$sheetView->setShowZeroes(false);
+$sheetView->setShowZeros(false);
 $sheetView->setRightToLeft(true); // Change sheet direction
 $sheetView->setTabSelected(false);
 $sheetView->setShowOutlineSymbols(false);

--- a/src/Common/Helper/FileSystemHelper.php
+++ b/src/Common/Helper/FileSystemHelper.php
@@ -53,7 +53,7 @@ final readonly class FileSystemHelper implements FileSystemHelperInterface
 
             return true;
         });
-        $wasCreationSuccessful = mkdir($folderPath, 0777, true);
+        $wasCreationSuccessful = mkdir($folderPath, 0o777, true);
         restore_error_handler();
 
         if (!$wasCreationSuccessful) {

--- a/src/Writer/XLSX/Entity/SheetView.php
+++ b/src/Writer/XLSX/Entity/SheetView.php
@@ -218,7 +218,7 @@ final class SheetView
             'showFormulas' => $this->showFormulas,
             'showGridLines' => $this->showGridLines,
             'showRowColHeaders' => $this->showRowColHeaders,
-            'showZeroes' => $this->showZeroes,
+            'showZeros' => $this->showZeroes,
             'rightToLeft' => $this->rightToLeft,
             'tabSelected' => $this->tabSelected,
             'showOutlineSymbols' => $this->showOutlineSymbols,

--- a/src/Writer/XLSX/Entity/SheetView.php
+++ b/src/Writer/XLSX/Entity/SheetView.php
@@ -12,7 +12,7 @@ final class SheetView
     private bool $showFormulas = false;
     private bool $showGridLines = true;
     private bool $showRowColHeaders = true;
-    private bool $showZeroes = true;
+    private bool $showZeros = true;
     private bool $rightToLeft = false;
     private bool $tabSelected = false;
     private bool $showOutlineSymbols = true;
@@ -59,10 +59,22 @@ final class SheetView
 
     /**
      * @return $this
+     *
+     * @deprecated Use {@see self::setShowZeros()} instead
      */
     public function setShowZeroes(bool $showZeroes): self
     {
-        $this->showZeroes = $showZeroes;
+        $this->setShowZeros($showZeroes);
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setShowZeros(bool $showZeros): self
+    {
+        $this->showZeros = $showZeros;
 
         return $this;
     }
@@ -218,7 +230,7 @@ final class SheetView
             'showFormulas' => $this->showFormulas,
             'showGridLines' => $this->showGridLines,
             'showRowColHeaders' => $this->showRowColHeaders,
-            'showZeros' => $this->showZeroes,
+            'showZeros' => $this->showZeros,
             'rightToLeft' => $this->rightToLeft,
             'tabSelected' => $this->tabSelected,
             'showOutlineSymbols' => $this->showOutlineSymbols,

--- a/tests/Common/Entity/CellTest.php
+++ b/tests/Common/Entity/CellTest.php
@@ -28,7 +28,7 @@ final class CellTest extends TestCase
         self::assertInstanceOf(NumericCell::class, Cell::fromValue(10.2));
         self::assertInstanceOf(NumericCell::class, Cell::fromValue(10.10000000000000000000001));
         self::assertInstanceOf(NumericCell::class, Cell::fromValue(0x539));
-        self::assertInstanceOf(NumericCell::class, Cell::fromValue(02471));
+        self::assertInstanceOf(NumericCell::class, Cell::fromValue(0o2471));
         self::assertInstanceOf(NumericCell::class, Cell::fromValue(0b10100111001));
         self::assertInstanceOf(NumericCell::class, Cell::fromValue(1337e0));
     }

--- a/tests/Common/Helper/FileSystemHelperTest.php
+++ b/tests/Common/Helper/FileSystemHelperTest.php
@@ -40,7 +40,7 @@ final class FileSystemHelperTest extends TestCase
     #[RequiresOperatingSystemFamily('Linux')]
     public function testCreateFolderShouldThrowExceptionWhenFails(): void
     {
-        self::assertTrue(chmod($this->baseFolder, 0500));
+        self::assertTrue(chmod($this->baseFolder, 0o500));
         $this->expectException(IOException::class);
         $this->expectExceptionMessage('Permission denied');
         $this->fileSystemHelper->createFolder($this->baseFolder, 'folder_name');
@@ -56,7 +56,7 @@ final class FileSystemHelperTest extends TestCase
     #[RequiresOperatingSystemFamily('Linux')]
     public function testCreateFileWithContentsShouldThrowExceptionIfFails(): void
     {
-        self::assertTrue(chmod($this->baseFolder, 0500));
+        self::assertTrue(chmod($this->baseFolder, 0o500));
         $this->expectException(IOException::class);
         $this->expectExceptionMessage('Permission denied');
         $this->fileSystemHelper->createFileWithContents($this->baseFolder, 'folder_name', 'contents');

--- a/tests/TestUsingResource.php
+++ b/tests/TestUsingResource.php
@@ -52,7 +52,7 @@ final readonly class TestUsingResource
         $resourceType = pathinfo($resourceName, PATHINFO_EXTENSION);
         $generatedResourcePathForType = $this->generatedResourcesPath.\DIRECTORY_SEPARATOR.strtolower($resourceType);
         if (!file_exists($generatedResourcePathForType)) {
-            mkdir($generatedResourcePathForType, 0700, true);
+            mkdir($generatedResourcePathForType, 0o700, true);
         }
 
         return $generatedResourcePathForType.\DIRECTORY_SEPARATOR.$resourceName;
@@ -70,10 +70,10 @@ final readonly class TestUsingResource
 
         if (!file_exists($this->generatedUnwritableResourcesPath)) {
             if (!file_exists($this->generatedResourcesPath)) {
-                mkdir($this->generatedResourcesPath, 0700, true);
+                mkdir($this->generatedResourcesPath, 0o700, true);
             }
 
-            mkdir($this->generatedUnwritableResourcesPath, 0500, true);
+            mkdir($this->generatedUnwritableResourcesPath, 0o500, true);
         }
 
         return realpath($this->generatedUnwritableResourcesPath).\DIRECTORY_SEPARATOR.$resourceName;
@@ -88,7 +88,7 @@ final readonly class TestUsingResource
             $this->deleteFolderRecursively($this->tempFolderPath);
         }
 
-        mkdir($this->tempFolderPath, 0700, true);
+        mkdir($this->tempFolderPath, 0o700, true);
 
         return $this->tempFolderPath;
     }

--- a/tests/Writer/Common/Helper/ZipHelperTest.php
+++ b/tests/Writer/Common/Helper/ZipHelperTest.php
@@ -23,7 +23,7 @@ final class ZipHelperTest extends TestCase
         ;
 
         $tempFolder = (new TestUsingResource())->getTempFolderPath();
-        mkdir($tempFolder.'/xl', 0700, true);
+        mkdir($tempFolder.'/xl', 0o700, true);
         touch($tempFolder.'/xl/workbook.xml');
 
         $rootFolderPath = $tempFolder;

--- a/tests/Writer/XLSX/SheetTest.php
+++ b/tests/Writer/XLSX/SheetTest.php
@@ -403,7 +403,7 @@ final class SheetTest extends TestCase
                 ->setShowFormulas(true)
                 ->setShowGridLines(false)
                 ->setShowRowColHeaders(false)
-                ->setShowZeroes(false)
+                ->setShowZeros(false)
                 ->setRightToLeft(false)
                 ->setTabSelected(false)
                 ->setShowOutlineSymbols(false)


### PR DESCRIPTION
Source: [ShowZer***os*** Original Specification](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.sheetview.showzeros?view=openxml-3.0.1)

Changes the key of `showZeroes` in line 221 of `SheetView.php` to `showZeros` to adhere to the specifications listed [above](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.sheetview.showzeros?view=openxml-3.0.1).