### PR TITLE
Comment column indexing in Options

### DIFF
--- a/src/Writer/Common/AbstractOptions.php
+++ b/src/Writer/Common/AbstractOptions.php
@@ -25,6 +25,8 @@ abstract class AbstractOptions
     }
 
     /**
+     * Columns are indexed from 1 (A = 1).
+     *
      * @param positive-int ...$columns One or more columns with this width
      */
     final public function setColumnWidth(float $width, int ...$columns): void
@@ -46,6 +48,8 @@ abstract class AbstractOptions
     }
 
     /**
+     * Columns are indexed from 1 (A = 1).
+     *
      * @param float        $width The width to set
      * @param positive-int $start First column index of the range
      * @param positive-int $end   Last column index of the range


### PR DESCRIPTION
Added comments that specify that column indexing is from 1 in methods setColumnWidth & setColumnWidthForRange.

Closes https://github.com/openspout/openspout/issues/320