### PR TITLE
Fix 321 - scientific notation reading causes InvalidValueException error

### DIFF
--- a/src/Reader/XLSX/Manager/StyleManager.php
+++ b/src/Reader/XLSX/Manager/StyleManager.php
@@ -30,6 +30,7 @@ class StyleManager implements StyleManagerInterface
     final public const DEFAULT_STYLE_ID = 0;
 
     final public const NUMBER_FORMAT_GENERAL = 'General';
+    final public const NUMBER_FORMAT_SCIENTIFIC = '0.00E+00';
 
     /**
      * Mapping between built-in numFmtId and the associated format - for dates only.
@@ -304,6 +305,11 @@ class StyleManager implements StyleManagerInterface
      */
     private function isFormatCodeMatchingDateFormatPattern(string $formatCode): bool
     {
+        // Scientific notation format containts "E", and will therefore be incorrectly considered as a date
+        if (self::NUMBER_FORMAT_SCIENTIFIC === $formatCode) {
+            return false;
+        }
+
         // Remove extra formatting (what's between [ ], the brackets should not be preceded by a "\")
         $pattern = '((?<!\\\)\[.+?(?<!\\\)\])';
         $formatCode = preg_replace($pattern, '', $formatCode);

--- a/tests/Reader/XLSX/Manager/StyleManagerTest.php
+++ b/tests/Reader/XLSX/Manager/StyleManagerTest.php
@@ -162,8 +162,8 @@ final class StyleManagerTest extends TestCase
         $styleManager = $this->getStyleManagerMock(
             [
                 1 => [
-                    "numFmtId" => 165,
-                    "applyNumberFormat" => null,
+                    'numFmtId' => 165,
+                    'applyNumberFormat' => null,
                 ],
             ],
             [

--- a/tests/Reader/XLSX/Manager/StyleManagerTest.php
+++ b/tests/Reader/XLSX/Manager/StyleManagerTest.php
@@ -156,4 +156,21 @@ final class StyleManagerTest extends TestCase
 
         return $styleManager;
     }
+
+    public function testShouldFormatScientificNotationAsDate(): void
+    {
+        $styleManager = $this->getStyleManagerMock(
+            [
+                1 => [
+                    "numFmtId" => 165,
+                    "applyNumberFormat" => null,
+                ]
+            ],
+            [
+                165 => '0.00E+00'
+            ]
+        );
+        $shouldFormatAsDate = $styleManager->shouldFormatNumericValueAsDate(1);
+        self::assertFalse($shouldFormatAsDate);
+    }
 }

--- a/tests/Reader/XLSX/Manager/StyleManagerTest.php
+++ b/tests/Reader/XLSX/Manager/StyleManagerTest.php
@@ -142,21 +142,6 @@ final class StyleManagerTest extends TestCase
         ];
     }
 
-    private function getStyleManagerMock(array $styleAttributes = [], array $customNumberFormats = []): StyleManager
-    {
-        /** @var MockObject|StyleManager $styleManager */
-        $styleManager = $this->getMockBuilder(StyleManager::class)
-            ->setConstructorArgs(['/path/to/file.xlsx', uniqid()])
-            ->onlyMethods(['getCustomNumberFormats', 'getStylesAttributes'])
-            ->getMock()
-        ;
-
-        $styleManager->method('getStylesAttributes')->willReturn($styleAttributes);
-        $styleManager->method('getCustomNumberFormats')->willReturn($customNumberFormats);
-
-        return $styleManager;
-    }
-
     public function testShouldFormatScientificNotationAsDate(): void
     {
         $styleManager = $this->getStyleManagerMock(
@@ -172,5 +157,20 @@ final class StyleManagerTest extends TestCase
         );
         $shouldFormatAsDate = $styleManager->shouldFormatNumericValueAsDate(1);
         self::assertFalse($shouldFormatAsDate);
+    }
+
+    private function getStyleManagerMock(array $styleAttributes = [], array $customNumberFormats = []): StyleManager
+    {
+        /** @var MockObject|StyleManager $styleManager */
+        $styleManager = $this->getMockBuilder(StyleManager::class)
+            ->setConstructorArgs(['/path/to/file.xlsx', uniqid()])
+            ->onlyMethods(['getCustomNumberFormats', 'getStylesAttributes'])
+            ->getMock()
+        ;
+
+        $styleManager->method('getStylesAttributes')->willReturn($styleAttributes);
+        $styleManager->method('getCustomNumberFormats')->willReturn($customNumberFormats);
+
+        return $styleManager;
     }
 }

--- a/tests/Reader/XLSX/Manager/StyleManagerTest.php
+++ b/tests/Reader/XLSX/Manager/StyleManagerTest.php
@@ -164,11 +164,11 @@ final class StyleManagerTest extends TestCase
                 1 => [
                     "numFmtId" => 165,
                     "applyNumberFormat" => null,
-                ]
+                ],
             ],
             [
-                165 => '0.00E+00'
-            ]
+                165 => '0.00E+00',
+            ],
         );
         $shouldFormatAsDate = $styleManager->shouldFormatNumericValueAsDate(1);
         self::assertFalse($shouldFormatAsDate);


### PR DESCRIPTION
Proposal fix for issue https://github.com/openspout/openspout/issues/321

Open to suggestion / cleaner solutions !
