### PR TITLE
Improve the error message when failing to open a ZipArchive

### DIFF
--- a/src/Reader/ODS/Reader.php
+++ b/src/Reader/ODS/Reader.php
@@ -55,8 +55,22 @@ final class Reader extends AbstractReader
     {
         $this->zip = new ZipArchive();
 
-        if (true !== $this->zip->open($filePath)) {
-            throw new IOException("Could not open {$filePath} for reading.");
+        $openResult = $this->zip->open($filePath);
+
+        if (true !== $openResult) {
+            $errorMessage = match ($openResult) {
+                ZipArchive::ER_INCONS => 'Zip archive inconsistent',
+                ZipArchive::ER_INVAL => 'Invalid argument',
+                ZipArchive::ER_MEMORY => 'Malloc failure',
+                ZipArchive::ER_NOENT => 'No such file',
+                ZipArchive::ER_NOZIP => 'Not a zip archive',
+                ZipArchive::ER_OPEN => 'Can\'t open file',
+                ZipArchive::ER_READ => 'Read error',
+                ZipArchive::ER_SEEK => 'Seek error',
+                default => 'Unknown error',
+            };
+
+            throw new IOException("Could not open {$filePath} for reading: {$errorMessage}.");
         }
 
         $this->sheetIterator = new SheetIterator($filePath, $this->options, new ODS(), new SettingsHelper());

--- a/src/Reader/XLSX/Reader.php
+++ b/src/Reader/XLSX/Reader.php
@@ -74,8 +74,22 @@ final class Reader extends AbstractReader
     {
         $this->zip = new ZipArchive();
 
-        if (true !== $this->zip->open($filePath)) {
-            throw new IOException("Could not open {$filePath} for reading.");
+        $openResult = $this->zip->open($filePath);
+
+        if (true !== $openResult) {
+            $errorMessage = match ($openResult) {
+                ZipArchive::ER_INCONS => 'Zip archive inconsistent',
+                ZipArchive::ER_INVAL => 'Invalid argument',
+                ZipArchive::ER_MEMORY => 'Malloc failure',
+                ZipArchive::ER_NOENT => 'No such file',
+                ZipArchive::ER_NOZIP => 'Not a zip archive',
+                ZipArchive::ER_OPEN => 'Can\'t open file',
+                ZipArchive::ER_READ => 'Read error',
+                ZipArchive::ER_SEEK => 'Seek error',
+                default => 'Unknown error',
+            };
+
+            throw new IOException("Could not open {$filePath} for reading: {$errorMessage}.");
         }
 
         $this->sharedStringsManager = new SharedStringsManager(


### PR DESCRIPTION
The `ZipArchive::open()` method can return an error code on failure, which allows providing a better exception message.