### PR TITLE
Fix coding standards

### DIFF
--- a/src/Common/Entity/Cell.php
+++ b/src/Common/Entity/Cell.php
@@ -27,7 +27,7 @@ abstract class Cell
         $this->setStyle($style);
     }
 
-    abstract public function getValue(): null|bool|DateInterval|DateTimeInterface|float|int|string;
+    abstract public function getValue(): bool|DateInterval|DateTimeInterface|float|int|string|null;
 
     final public function setStyle(?Style $style): void
     {
@@ -39,7 +39,7 @@ abstract class Cell
         return $this->style;
     }
 
-    final public static function fromValue(null|bool|DateInterval|DateTimeInterface|float|int|string $value, ?Style $style = null): self
+    final public static function fromValue(bool|DateInterval|DateTimeInterface|float|int|string|null $value, ?Style $style = null): self
     {
         if (\is_bool($value)) {
             return new BooleanCell($value, $style);

--- a/src/Common/Entity/Cell/FormulaCell.php
+++ b/src/Common/Entity/Cell/FormulaCell.php
@@ -14,7 +14,7 @@ final class FormulaCell extends Cell
     public function __construct(
         private readonly string $value,
         ?Style $style,
-        private readonly null|bool|DateInterval|DateTimeImmutable|float|int|string $computedValue = null,
+        private readonly bool|DateInterval|DateTimeImmutable|float|int|string|null $computedValue = null,
     ) {
         parent::__construct($style);
     }
@@ -24,7 +24,7 @@ final class FormulaCell extends Cell
         return $this->value;
     }
 
-    public function getComputedValue(): null|bool|DateInterval|DateTimeImmutable|float|int|string
+    public function getComputedValue(): bool|DateInterval|DateTimeImmutable|float|int|string|null
     {
         return $this->computedValue;
     }

--- a/src/Common/Entity/Row.php
+++ b/src/Common/Entity/Row.php
@@ -41,7 +41,7 @@ final class Row
      */
     public static function fromValues(array $cellValues = [], ?Style $rowStyle = null): self
     {
-        $cells = array_map(static function (null|bool|DateInterval|DateTimeInterface|float|int|string $cellValue): Cell {
+        $cells = array_map(static function (bool|DateInterval|DateTimeInterface|float|int|string|null $cellValue): Cell {
             return Cell::fromValue($cellValue);
         }, $cellValues);
 
@@ -54,7 +54,7 @@ final class Row
      */
     public static function fromValuesWithStyles(array $cellValues = [], ?Style $rowStyle = null, array $columnStyles = []): self
     {
-        $cells = array_map(static function (null|bool|DateInterval|DateTimeInterface|float|int|string $cellValue, int|string $key) use ($columnStyles): Cell {
+        $cells = array_map(static function (bool|DateInterval|DateTimeInterface|float|int|string|null $cellValue, int|string $key) use ($columnStyles): Cell {
             return Cell::fromValue($cellValue, $columnStyles[$key] ?? null);
         }, $cellValues, array_keys($cellValues));
 
@@ -147,7 +147,7 @@ final class Row
      */
     public function toArray(): array
     {
-        return array_map(static function (Cell $cell): null|bool|DateInterval|DateTimeInterface|float|int|string {
+        return array_map(static function (Cell $cell): bool|DateInterval|DateTimeInterface|float|int|string|null {
             return $cell->getValue();
         }, $this->cells);
     }

--- a/tests/Reader/XLSX/Helper/CellValueFormatterTest.php
+++ b/tests/Reader/XLSX/Helper/CellValueFormatterTest.php
@@ -146,7 +146,7 @@ final class CellValueFormatterTest extends TestCase
         string $nodeValue,
         bool $shouldFormatAsDate,
         float|int|string $computedValue,
-        null|float|int|string $expectedComputedValue,
+        float|int|string|null $expectedComputedValue,
         string $cellType
     ): void {
         $nodeListMock = $this->createMock(DOMNodeList::class);


### PR DESCRIPTION
The latest version of php-cs-fixer enforces `null` to come last in union types in the configuration being used.