### PR TITLE
Add Row::fromValuesWithStyle helper

### DIFF
--- a/src/Common/Entity/Row.php
+++ b/src/Common/Entity/Row.php
@@ -103,4 +103,16 @@ final readonly class Row
 
         return new self($cells, $height);
     }
+
+    /**
+     * @param array<non-negative-int, null|bool|DateInterval|DateTimeInterface|float|int|string> $cellValues
+     */
+    public static function fromValuesWithStyle(array $cellValues, Style $cellStyle, float $height = 0): self
+    {
+        $cells = array_map(static function (bool|DateInterval|DateTimeInterface|float|int|string|null $cellValue) use ($cellStyle): Cell {
+            return Cell::fromValue($cellValue, $cellStyle);
+        }, $cellValues);
+
+        return new self($cells, $height);
+    }
 }

--- a/tests/Writer/ODS/WriterWithStyleTest.php
+++ b/tests/Writer/ODS/WriterWithStyleTest.php
@@ -354,6 +354,24 @@ final class WriterWithStyleTest extends TestCase
         self::assertSame($defaultFontSize.'pt', $textPropertiesElement->getAttribute('fo:font-size'));
     }
 
+    public function testSetSingleStyleForTheRow(): void
+    {
+        $fileName = 'test_set_custom_style.ods';
+
+        $dataRows = [
+            Row::fromValues(['row1-c1', 'row1-c2', 'row1-c3']),
+            Row::fromValuesWithStyle(['row2-c1', 'row2-c2', 'row2-c3'], new Style(fontColor: Color::GREEN)),
+        ];
+
+        $this->writeToODSFile($dataRows, $fileName);
+
+        $styleElements = $this->getCellStyleElementsFromContentXmlFile($fileName);
+        self::assertCount(2, $styleElements, 'There should be 2 styles (default and custom)');
+
+        $customStyleElement = $styleElements[1];
+        $this->assertFirstChildHasAttributeEquals('#'.Color::GREEN, $customStyleElement, 'text-properties', 'fo:color');
+    }
+
     /**
      * @param Row[] $allRows
      */


### PR DESCRIPTION
Addresses #339

Allows users to apply a single style to all cells in the row without creating unnecessary arrays

```php
// 5.0:

// we need to create a variable even if a row is hardcoded
$cellValues = ['column 1', 'column 2', 'column 3'];
// we need to count items and create an array
$columnStyles = array_fill(0, count($cellValues), new Style());

$writer->addRow(Row::fromValuesWithStyles($cellValues, $columnStyles));

// MR:
$writer->addRow(Row::fromValuesWithStyle(['column 1', 'column 2', 'column 3'], new Style()));
```

Adds a new method instead of reintroducing `$rowStyle` to `fromValues` to indicate its semantic difference