### PR TITLE
Ensure associative arrays are accepted by `Row` named constructors

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25,12 +25,6 @@ parameters:
 			path: src/Common/Entity/Row.php
 
 		-
-			message: '#^Method OpenSpout\\Common\\Entity\\Row\:\:toArray\(\) should return list\<bool\|DateInterval\|DateTimeInterface\|float\|int\|string\|null\> but returns array\<int\<0, max\>, bool\|DateInterval\|DateTimeInterface\|float\|int\|string\|null\>\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Common/Entity/Row.php
-
-		-
 			message: '#^Result of \|\| is always false\.$#'
 			identifier: booleanOr.alwaysFalse
 			count: 1

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,12 +5,16 @@
          failOnDeprecation="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
+         failOnPhpunitNotice="true"
          beStrictAboutChangesToGlobalState="true"
          beStrictAboutOutputDuringTests="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         displayDetailsOnPhpunitNotices="true"
          cacheDirectory=".phpunit.cache"
 >
   <php>

--- a/src/Common/Entity/Row.php
+++ b/src/Common/Entity/Row.php
@@ -66,7 +66,7 @@ final readonly class Row
     }
 
     /**
-     * @return list<null|bool|DateInterval|DateTimeInterface|float|int|string> The row values, as array
+     * @return array<non-negative-int, null|bool|DateInterval|DateTimeInterface|float|int|string> The row values, as array
      */
     public function toArray(): array
     {
@@ -95,7 +95,7 @@ final readonly class Row
             return Cell::fromValue($cellValue);
         }, $cellValues);
 
-        return new self($cells, $height);
+        return new self(array_values($cells), $height);
     }
 
     /**
@@ -120,6 +120,6 @@ final readonly class Row
             return Cell::fromValue($cellValue, $cellStyle);
         }, $cellValues);
 
-        return new self($cells, $height);
+        return new self(array_values($cells), $height);
     }
 }

--- a/tests/Common/Entity/RowTest.php
+++ b/tests/Common/Entity/RowTest.php
@@ -65,12 +65,20 @@ final class RowTest extends TestCase
         self::assertSame(10.0, $newRow->height);
     }
 
-    public function testAcceptsAssociativeArrays(): void
+    public function testAcceptsAssociativeArraysInNamedConstructors(): void
     {
+        $row = Row::fromValues(['foo', 'bar' => 'baz']);
+        self::assertIsList($row->cells);
+
         $style = new Style();
         $row = Row::fromValuesWithStyles(['a' => 1, 'b' => 2], ['b' => $style]);
 
+        self::assertIsList($row->cells);
         self::assertNull($row->cells[0]->style);
         self::assertSame($style, $row->cells[1]->style);
+
+        $row = Row::fromValuesWithStyle(['a' => 1, 'b' => 2], $style);
+
+        self::assertIsList($row->cells);
     }
 }

--- a/tests/Reader/XLSX/Helper/CellValueFormatterTest.php
+++ b/tests/Reader/XLSX/Helper/CellValueFormatterTest.php
@@ -342,7 +342,7 @@ final class CellValueFormatterTest extends TestCase
                 new WorkbookRelationshipsManager(uniqid()),
                 new CachingStrategyFactory(new MemoryLimit('1'))
             ),
-            $this->createMock(StyleManagerInterface::class),
+            self::createStub(StyleManagerInterface::class),
             false,
             false,
             new Escaper\XLSX()

--- a/tests/Reader/XLSX/Manager/StyleManagerTest.php
+++ b/tests/Reader/XLSX/Manager/StyleManagerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OpenSpout\Reader\XLSX\Manager;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -159,13 +159,12 @@ final class StyleManagerTest extends TestCase
         self::assertFalse($shouldFormatAsDate);
     }
 
-    private function getStyleManagerMock(array $styleAttributes = [], array $customNumberFormats = []): StyleManager
+    private function getStyleManagerMock(array $styleAttributes = [], array $customNumberFormats = []): Stub&StyleManager
     {
-        /** @var MockObject|StyleManager $styleManager */
-        $styleManager = $this->getMockBuilder(StyleManager::class)
+        $styleManager = self::getStubBuilder(StyleManager::class)
             ->setConstructorArgs(['/path/to/file.xlsx', uniqid()])
             ->onlyMethods(['getCustomNumberFormats', 'getStylesAttributes'])
-            ->getMock()
+            ->getStub()
         ;
 
         $styleManager->method('getStylesAttributes')->willReturn($styleAttributes);

--- a/tests/Writer/XLSX/Manager/Style/StyleManagerTest.php
+++ b/tests/Writer/XLSX/Manager/Style/StyleManagerTest.php
@@ -17,10 +17,10 @@ final class StyleManagerTest extends TestCase
     #[DataProvider('provideShouldApplyStyleOnEmptyCellCases')]
     public function testShouldApplyStyleOnEmptyCell(?int $fillId, ?int $borderId, bool $expectedResult): void
     {
-        $styleRegistryMock = $this->getMockBuilder(StyleRegistry::class)
+        $styleRegistryMock = self::getStubBuilder(StyleRegistry::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getFillIdForStyleId', 'getBorderIdForStyleId'])
-            ->getMock()
+            ->getStub()
         ;
 
         $styleRegistryMock


### PR DESCRIPTION
Fix https://github.com/openspout/openspout/issues/345