### PR TITLE
Prevent OpenSpout export errors for cell values over 32,767 characters

### DIFF
--- a/src/Writer/XLSX/Manager/WorksheetManager.php
+++ b/src/Writer/XLSX/Manager/WorksheetManager.php
@@ -161,7 +161,7 @@ final readonly class WorksheetManager implements WorksheetManagerInterface
     private function getCellXMLFragmentForNonEmptyString(string $cellValue): string
     {
         if ($this->stringHelper->getStringLength($cellValue) > self::MAX_CHARACTERS_PER_CELL) {
-            throw new InvalidArgumentException('Trying to add a value that exceeds the maximum number of characters allowed in a cell (32,767)');
+            $cellValue = mb_substr($cellValue, 0, self::MAX_CHARACTERS_PER_CELL, 'UTF-8');
         }
 
         if ($this->options->SHOULD_USE_INLINE_STRINGS) {


### PR DESCRIPTION
Hi @Slamdunk, 

I’ve raised this PR to address an issue encountered after switching from PhpOffice to OpenSpout.

Previously, PhpOffice handled cases where a cell’s content exceeded Excel’s 32,767 character limit by internally managing or truncating the data. After migrating to OpenSpout, the same scenario now results in an exception being thrown when the character limit is exceeded.

To ensure compatibility with Excel constraints and maintain stability, this PR proposes trimming any extra characters beyond the 32,767 limit before writing the value to the cell.

This change aligns the behavior with Excel’s specifications and avoids runtime errors while exporting large datasets.

Please let me know if you’d prefer a different approach or additional safeguards.

Thank You