### PR TITLE
feat: Add XLSX Writer TextRun formatting

### DIFF
--- a/src/Common/Entity/Cell.php
+++ b/src/Common/Entity/Cell.php
@@ -15,6 +15,7 @@ use OpenSpout\Common\Entity\Cell\NumericCell;
 use OpenSpout\Common\Entity\Cell\StringCell;
 use OpenSpout\Common\Entity\Cell\TextRunCell;
 use OpenSpout\Common\Entity\Comment\Comment;
+use OpenSpout\Common\Entity\Comment\TextRun;
 use OpenSpout\Common\Entity\Style\Style;
 
 abstract readonly class Cell
@@ -24,6 +25,9 @@ abstract readonly class Cell
         public ?Comment $comment = null,
     ) {}
 
+    /**
+     * @return null|bool|DateInterval|DateTimeInterface|float|int|string|TextRun[]
+     */
     abstract public function getValue(): array|bool|DateInterval|DateTimeInterface|float|int|string|null;
 
     abstract public function withStyle(Style $style): static;
@@ -34,6 +38,12 @@ abstract readonly class Cell
 
     abstract public function withoutComment(): static;
 
+    /**
+     * @param null|bool|DateInterval|DateTimeInterface|float|int|string|TextRun[] $value
+     * @param Style|null $style
+     * @param Comment|null $comment
+     * @return self
+     */
     final public static function fromValue(
         array|bool|DateInterval|DateTimeInterface|float|int|string|null $value,
         ?Style $style = null,

--- a/src/Common/Entity/Cell.php
+++ b/src/Common/Entity/Cell.php
@@ -13,6 +13,7 @@ use OpenSpout\Common\Entity\Cell\EmptyCell;
 use OpenSpout\Common\Entity\Cell\FormulaCell;
 use OpenSpout\Common\Entity\Cell\NumericCell;
 use OpenSpout\Common\Entity\Cell\StringCell;
+use OpenSpout\Common\Entity\Cell\TextRunCell;
 use OpenSpout\Common\Entity\Comment\Comment;
 use OpenSpout\Common\Entity\Style\Style;
 
@@ -23,7 +24,7 @@ abstract readonly class Cell
         public ?Comment $comment = null,
     ) {}
 
-    abstract public function getValue(): bool|DateInterval|DateTimeInterface|float|int|string|null;
+    abstract public function getValue(): array|bool|DateInterval|DateTimeInterface|float|int|string|null;
 
     abstract public function withStyle(Style $style): static;
 
@@ -34,10 +35,13 @@ abstract readonly class Cell
     abstract public function withoutComment(): static;
 
     final public static function fromValue(
-        bool|DateInterval|DateTimeInterface|float|int|string|null $value,
+        array|bool|DateInterval|DateTimeInterface|float|int|string|null $value,
         ?Style $style = null,
         ?Comment $comment = null,
     ): self {
+        if (\is_array($value)) {
+            return new TextRunCell($value, $style, $comment);
+        }
         if (\is_bool($value)) {
             return new BooleanCell($value, $style, $comment);
         }

--- a/src/Common/Entity/Cell.php
+++ b/src/Common/Entity/Cell.php
@@ -40,9 +40,6 @@ abstract readonly class Cell
 
     /**
      * @param null|bool|DateInterval|DateTimeInterface|float|int|string|TextRun[] $value
-     * @param Style|null $style
-     * @param Comment|null $comment
-     * @return self
      */
     final public static function fromValue(
         array|bool|DateInterval|DateTimeInterface|float|int|string|null $value,

--- a/src/Common/Entity/Cell/TextRunCell.php
+++ b/src/Common/Entity/Cell/TextRunCell.php
@@ -15,8 +15,6 @@ final readonly class TextRunCell extends Cell
     private array $textRuns;
 
     /**
-     * @param Style|null $style
-     * @param Comment|null $comment
      * @param TextRun[] $textRuns
      */
     public function __construct(

--- a/src/Common/Entity/Cell/TextRunCell.php
+++ b/src/Common/Entity/Cell/TextRunCell.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSpout\Common\Entity\Cell;
+
+use OpenSpout\Common\Entity\Cell;
+use OpenSpout\Common\Entity\Comment\Comment;
+use OpenSpout\Common\Entity\Comment\TextRun;
+use OpenSpout\Common\Entity\Style\Style;
+
+final readonly class TextRunCell extends Cell
+{
+    /** @var TextRun[] */
+    private array $textRuns;
+
+    /**
+     * @param Style|null $style
+     * @param Comment|null $comment
+     * @param TextRun[] $textRuns
+     */
+    public function __construct(
+        array $textRuns,
+        ?Style $style,
+        ?Comment $comment,
+    ) {
+        parent::__construct($style, $comment);
+        $this->textRuns = $textRuns;
+    }
+
+    /**
+     * @return TextRun[]
+     */
+    public function getValue(): array
+    {
+        return $this->textRuns;
+    }
+
+    public function getStringValue(): string
+    {
+        $value = '';
+        foreach ($this->textRuns as $textRun) {
+            $value .= $textRun->text;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param TextRun ...$textRuns
+     */
+    public function withTextRuns(...$textRuns): self
+    {
+        return new self($textRuns, $this->style, $this->comment);
+    }
+
+    public function withStyle(Style $style): static
+    {
+        return new self($this->textRuns, $style, $this->comment);
+    }
+
+    public function withoutStyle(): static
+    {
+        return new self($this->textRuns, null, $this->comment);
+    }
+
+    public function withComment(Comment $comment): static
+    {
+        return new self($this->textRuns, $this->style, $comment);
+    }
+
+    public function withoutComment(): static
+    {
+        return new self($this->textRuns, $this->style, null);
+    }
+}

--- a/src/Common/Entity/Comment/TextRun.php
+++ b/src/Common/Entity/Comment/TextRun.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OpenSpout\Common\Entity\Comment;
 
+use OpenSpout\Common\Entity\Style\TextRunVerticalStyle;
+
 /**
  * This class defines rich text in a fluent interface that can be added to a comment.
  */
@@ -20,35 +22,51 @@ final readonly class TextRun
         public string $fontName = self::DEFAULT_FONT_NAME,
         public bool $bold = false,
         public bool $italic = false,
+        public ?TextRunVerticalStyle $verticalStyle = null,
     ) {}
+
+    public function withSuperscript(): self
+    {
+        return new self($this->text, $this->fontSize, $this->fontColor, $this->fontName, $this->bold, $this->italic, TextRunVerticalStyle::SUPERSCRIPT);
+    }
+
+    public function withSubscript(): self
+    {
+        return new self($this->text, $this->fontSize, $this->fontColor, $this->fontName, $this->bold, $this->italic, TextRunVerticalStyle::SUBSCRIPT);
+    }
+
+    public function withoutVerticalStyle(): self
+    {
+        return new self($this->text, $this->fontSize, $this->fontColor, $this->fontName, $this->bold, $this->italic, null);
+    }
 
     public function withText(string $text): self
     {
-        return new self($text, $this->fontSize, $this->fontColor, $this->fontName, $this->bold, $this->italic);
+        return new self($text, $this->fontSize, $this->fontColor, $this->fontName, $this->bold, $this->italic, $this->verticalStyle);
     }
 
     public function withFontSize(int $fontSize): self
     {
-        return new self($this->text, $fontSize, $this->fontColor, $this->fontName, $this->bold, $this->italic);
+        return new self($this->text, $fontSize, $this->fontColor, $this->fontName, $this->bold, $this->italic, $this->verticalStyle);
     }
 
     public function withFontColor(string $fontColor): self
     {
-        return new self($this->text, $this->fontSize, $fontColor, $this->fontName, $this->bold, $this->italic);
+        return new self($this->text, $this->fontSize, $fontColor, $this->fontName, $this->bold, $this->italic, $this->verticalStyle);
     }
 
     public function withFontName(string $fontName): self
     {
-        return new self($this->text, $this->fontSize, $this->fontColor, $fontName, $this->bold, $this->italic);
+        return new self($this->text, $this->fontSize, $this->fontColor, $fontName, $this->bold, $this->italic, $this->verticalStyle);
     }
 
     public function withBold(bool $bold): self
     {
-        return new self($this->text, $this->fontSize, $this->fontColor, $this->fontName, $bold, $this->italic);
+        return new self($this->text, $this->fontSize, $this->fontColor, $this->fontName, $bold, $this->italic, $this->verticalStyle);
     }
 
     public function withItalic(bool $italic): self
     {
-        return new self($this->text, $this->fontSize, $this->fontColor, $this->fontName, $this->bold, $italic);
+        return new self($this->text, $this->fontSize, $this->fontColor, $this->fontName, $this->bold, $italic, $this->verticalStyle);
     }
 }

--- a/src/Common/Entity/Row.php
+++ b/src/Common/Entity/Row.php
@@ -7,6 +7,7 @@ namespace OpenSpout\Common\Entity;
 use DateInterval;
 use DateTimeInterface;
 use InvalidArgumentException;
+use OpenSpout\Common\Entity\Comment\TextRun;
 use OpenSpout\Common\Entity\Style\Style;
 
 final readonly class Row
@@ -66,11 +67,11 @@ final readonly class Row
     }
 
     /**
-     * @return array<non-negative-int, null|bool|DateInterval|DateTimeInterface|float|int|string> The row values, as array
+     * @return array<non-negative-int, null|bool|DateInterval|DateTimeInterface|float|int|string|TextRun[]> The row values, as array
      */
     public function toArray(): array
     {
-        return array_map(static function (Cell $cell): bool|DateInterval|DateTimeInterface|float|int|string|null {
+        return array_map(static function (Cell $cell): array|bool|DateInterval|DateTimeInterface|float|int|string|null {
             return $cell->getValue();
         }, $this->cells);
     }
@@ -87,11 +88,11 @@ final readonly class Row
     }
 
     /**
-     * @param array<array-key, null|bool|DateInterval|DateTimeInterface|float|int|string> $cellValues
+     * @param array<array-key, null|bool|DateInterval|DateTimeInterface|float|int|string|TextRun[]> $cellValues
      */
     public static function fromValues(array $cellValues, float $height = self::DEFAULT_HEIGHT): self
     {
-        $cells = array_map(static function (bool|DateInterval|DateTimeInterface|float|int|string|null $cellValue): Cell {
+        $cells = array_map(static function (array|bool|DateInterval|DateTimeInterface|float|int|string|null $cellValue): Cell {
             return Cell::fromValue($cellValue);
         }, $cellValues);
 
@@ -99,12 +100,12 @@ final readonly class Row
     }
 
     /**
-     * @param array<array-key, null|bool|DateInterval|DateTimeInterface|float|int|string> $cellValues
-     * @param array<array-key, Style>                                                     $columnStyles
+     * @param array<array-key, null|bool|DateInterval|DateTimeInterface|float|int|string|TextRun[]> $cellValues
+     * @param array<array-key, Style>                                                               $columnStyles
      */
     public static function fromValuesWithStyles(array $cellValues, array $columnStyles, float $height = self::DEFAULT_HEIGHT): self
     {
-        $cells = array_map(static function (bool|DateInterval|DateTimeInterface|float|int|string|null $cellValue, int|string $key) use ($columnStyles): Cell {
+        $cells = array_map(static function (array|bool|DateInterval|DateTimeInterface|float|int|string|null $cellValue, int|string $key) use ($columnStyles): Cell {
             return Cell::fromValue($cellValue, $columnStyles[$key] ?? null);
         }, $cellValues, array_keys($cellValues));
 
@@ -112,11 +113,11 @@ final readonly class Row
     }
 
     /**
-     * @param array<array-key, null|bool|DateInterval|DateTimeInterface|float|int|string> $cellValues
+     * @param array<array-key, null|bool|DateInterval|DateTimeInterface|float|int|string|TextRun[]> $cellValues
      */
     public static function fromValuesWithStyle(array $cellValues, Style $cellStyle, float $height = self::DEFAULT_HEIGHT): self
     {
-        $cells = array_map(static function (bool|DateInterval|DateTimeInterface|float|int|string|null $cellValue) use ($cellStyle): Cell {
+        $cells = array_map(static function (array|bool|DateInterval|DateTimeInterface|float|int|string|null $cellValue) use ($cellStyle): Cell {
             return Cell::fromValue($cellValue, $cellStyle);
         }, $cellValues);
 

--- a/src/Common/Entity/Style/TextRunVerticalStyle.php
+++ b/src/Common/Entity/Style/TextRunVerticalStyle.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSpout\Common\Entity\Style;
+
+enum TextRunVerticalStyle: string
+{
+    case SUPERSCRIPT = 'superscript';
+    case SUBSCRIPT = 'subscript';
+}

--- a/src/Writer/XLSX/Manager/SharedStringsManager.php
+++ b/src/Writer/XLSX/Manager/SharedStringsManager.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OpenSpout\Writer\XLSX\Manager;
 
+use OpenSpout\Common\Entity\Comment\TextRun;
+use OpenSpout\Common\Entity\Style\TextRunVerticalStyle;
 use OpenSpout\Common\Helper\Escaper;
 
 /**
@@ -67,6 +69,27 @@ final class SharedStringsManager
     }
 
     /**
+     * Writes the given string with text run formatting into the sharedStrings.xml file.
+     * Starting and ending whitespaces are preserved.
+     *
+     * @param TextRun[] $textRuns
+     *
+     * @return int ID of the written shared string
+     */
+    public function writeTextRuns(array $textRuns): int
+    {
+        fwrite($this->sharedStringsFilePointer, '<si>');
+        foreach ($textRuns as $textRun) {
+            $this->writeTextRunString($textRun);
+        }
+        fwrite($this->sharedStringsFilePointer, '</si>');
+        ++$this->numSharedStrings;
+
+        // Shared string ID is zero-based
+        return $this->numSharedStrings - 1;
+    }
+
+    /**
      * Finishes writing the data in the sharedStrings.xml file and closes the file.
      */
     public function close(): void
@@ -82,5 +105,41 @@ final class SharedStringsManager
         fwrite($this->sharedStringsFilePointer, \sprintf("%-{$defaultStringsCountPartLength}s", 'count="'.$this->numSharedStrings.'" uniqueCount="'.$this->numSharedStrings.'"'));
 
         fclose($this->sharedStringsFilePointer);
+    }
+
+    /**
+     * Writes the given text run string into the sharedStrings.xml file.
+     */
+    private function writeTextRunString(TextRun $textRun): void
+    {
+        $propertiesXml = '<rPr>';
+        if ($textRun->bold) {
+            $propertiesXml .= '<b/>';
+        }
+
+        if ($textRun->italic) {
+            $propertiesXml .= '<i/>';
+        }
+
+        if (TextRunVerticalStyle::SUBSCRIPT === $textRun->verticalStyle) {
+            $propertiesXml .= '<vertAlign val="subscript"/>';
+        } elseif (TextRunVerticalStyle::SUPERSCRIPT === $textRun->verticalStyle) {
+            $propertiesXml .= '<vertAlign val="superscript"/>';
+        }
+
+        if (TextRun::DEFAULT_FONT_SIZE !== $textRun->fontSize) {
+            $propertiesXml .= '<sz val="'.$textRun->fontSize.'"/>';
+        }
+
+        if (TextRun::DEFAULT_FONT_COLOR !== $textRun->fontColor) {
+            $propertiesXml .= '<color rgb="'.$textRun->fontColor.'"/>';
+        }
+
+        if (TextRun::DEFAULT_FONT_NAME !== $textRun->fontName) {
+            $propertiesXml .= '<rFont val="'.$textRun->fontName.'"/>';
+        }
+        $propertiesXml .= '</rPr>';
+
+        fwrite($this->sharedStringsFilePointer, '<r>'.$propertiesXml.'<t xml:space="preserve">'.$this->stringsEscaper->escape($textRun->text).'</t></r>');
     }
 }

--- a/src/Writer/XLSX/Manager/WorksheetManager.php
+++ b/src/Writer/XLSX/Manager/WorksheetManager.php
@@ -136,6 +136,9 @@ final readonly class WorksheetManager implements WorksheetManagerInterface
         } elseif ($cell instanceof Cell\ErrorCell) {
             // only writes the error value if it's a string
             $cellXML .= ' t="e"><v>'.$this->stringsEscaper->escape($cell->getRawValue()).'</v></c>';
+        } elseif ($cell instanceof Cell\TextRunCell) {
+            $sharedStringId = $this->sharedStringsManager->writeTextRuns($cell->getValue());
+            $cellXML .= ' t="s"><v>'.$sharedStringId.'</v></c>';
         } elseif ($cell instanceof Cell\EmptyCell) {
             if ($this->styleManager->shouldApplyStyleOnEmptyCell($styleId)) {
                 $cellXML .= '/>';

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -14,6 +14,7 @@ use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Common\Entity\Comment\Comment;
 use OpenSpout\Common\Entity\Comment\TextRun;
 use OpenSpout\Common\Entity\Row;
+use OpenSpout\Common\Entity\Style\TextRunVerticalStyle;
 use OpenSpout\Common\Exception\IOException;
 use OpenSpout\Reader\Wrapper\XMLReader;
 use OpenSpout\TestUsingResource;
@@ -35,6 +36,46 @@ use ReflectionHelper;
  */
 final class WriterTest extends TestCase
 {
+    public function testWriteTextRunFormatting(): void
+    {
+        $fileName = 'test_text_run_formatting.xlsx';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+        $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
+
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+
+        $row = new Row([
+            Cell::fromValue([
+                new TextRun('bold', bold: true),
+                new TextRun('superscript', verticalStyle: TextRunVerticalStyle::SUPERSCRIPT),
+                new TextRun('subscript', verticalStyle: TextRunVerticalStyle::SUBSCRIPT),
+                new TextRun('fontSize', fontSize: 12),
+                new TextRun('fontCalibri', fontName: 'Calibri'),
+                new TextRun('italic', italic: true),
+                new TextRun('fontColor', fontColor: '000001'),
+            ])
+        ]);
+
+        $writer->addRow($row);
+        $writer->close();
+
+        // Now test if the resources contain what we need
+        $pathToSheetFile = $resourcePath.'#xl/sharedStrings.xml';
+        $xmlContents = file_get_contents('zip://'.$pathToSheetFile);
+        self::assertNotFalse($xmlContents);
+        $xml = new DOMDocument();
+        self::assertTrue($xml->loadXML($xmlContents), 'sharedStrings is valid XML');
+
+        self::assertStringContainsString('<b/>', $xmlContents, 'Text run does not format bold');
+        self::assertStringContainsString('<i/>', $xmlContents, 'Text run does not format italic');
+        self::assertStringContainsString('<sz val="12"/>', $xmlContents, 'Text run does not format font size');
+        self::assertStringContainsString('<vertAlign val="superscript"/>', $xmlContents, 'Text run does not format superscript text');
+        self::assertStringContainsString('<vertAlign val="subscript"/>', $xmlContents, 'Text run does not format subscript text');
+        self::assertStringContainsString('<rFont val="Calibri"/>', $xmlContents, 'Text run does not format font');
+        self::assertStringContainsString('<color rgb="000001"/>', $xmlContents, 'Text run does not format font color');
+    }
+
     public function testAddRowShouldThrowExceptionIfCannotOpenAFileForWriting(): void
     {
         $fileName = 'file_that_wont_be_written.xlsx';

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -54,7 +54,7 @@ final class WriterTest extends TestCase
                 new TextRun('fontCalibri', fontName: 'Calibri'),
                 new TextRun('italic', italic: true),
                 new TextRun('fontColor', fontColor: '000001'),
-            ])
+            ]),
         ]);
 
         $writer->addRow($row);


### PR DESCRIPTION
Currently XLSX Writer only supports Row/Cell formatting, this pull request adds ability to create **TextRunCell** which supports cell text formatting like:

- Bold
- Subscript/Superscript
- Itallic
- Font
- Font size
- Font color
For example using code my sample code:
```php
$options = new WriterOptions();
$writer = new Writer($options);
$writer->openToFile('./test.xlsx');
$sheet = $writer->getCurrentSheet();
$row = new Row([
    Cell::fromValue([
        new TextRun('bold', bold: true),
        new TextRun('superscript', verticalStyle: TextRunVerticalStyle::SUPERSCRIPT),
        new TextRun('subscript', verticalStyle: TextRunVerticalStyle::SUBSCRIPT),
        new TextRun('fontSize', fontSize: 12),
        new TextRun('fontCalibri', fontName: 'Calibri'),
        new TextRun('italic', italic: true),
        new TextRun('fontColor', fontColor: 'FF0000'),
    ])
]);

$writer->addRow($row);
$writer->close();
```
It generates this:
<img width="462" height="91" alt="image" src="https://github.com/user-attachments/assets/d363d08b-8751-4298-807f-bfd95a22e476" />


It works by adding **<rPr>** RunProperties node to **<r>** run node
<img width="377" height="436" alt="image" src="https://github.com/user-attachments/assets/4134ad12-676c-437a-a549-bc660fff3976" />


Link to RunProperties documentation: https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.runproperties?view=openxml-3.0.1