### PR TITLE
feat: add FIELD_ESCAPE option for CSV reader and EOL option for CSV w…

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -11,6 +11,7 @@ use OpenSpout\Reader\CSV\Options;
 $reader = new Reader(new Options(
     FIELD_DELIMITER: '|',
     FIELD_ENCLOSURE: '@',
+    FIELD_ESCAPE: '\\',
 ));
 ```
 
@@ -34,6 +35,18 @@ use OpenSpout\Writer\CSV\Options;
 
 $writer = new Writer(new Options(
     SHOULD_ADD_BOM: false,
+));
+```
+
+The writer also supports customizing the line ending (EOL).
+By default, the EOL is `"\n"` (LF). To produce [RFC 4180](https://www.rfc-editor.org/rfc/rfc4180) compliant CSV files, set the EOL to `"\r\n"` (CRLF):
+
+```php
+use OpenSpout\Writer\CSV\Writer;
+use OpenSpout\Writer\CSV\Options;
+
+$writer = new Writer(new Options(
+    EOL: "\r\n",
 ));
 ```
 

--- a/src/Reader/CSV/Options.php
+++ b/src/Reader/CSV/Options.php
@@ -12,6 +12,7 @@ final readonly class Options
         public bool $SHOULD_PRESERVE_EMPTY_ROWS = false,
         public string $FIELD_DELIMITER = ',',
         public string $FIELD_ENCLOSURE = '"',
+        public string $FIELD_ESCAPE = '',
         public string $ENCODING = EncodingHelper::ENCODING_UTF8,
     ) {}
 }

--- a/src/Reader/CSV/Options.php
+++ b/src/Reader/CSV/Options.php
@@ -12,7 +12,7 @@ final readonly class Options
         public bool $SHOULD_PRESERVE_EMPTY_ROWS = false,
         public string $FIELD_DELIMITER = ',',
         public string $FIELD_ENCLOSURE = '"',
-        public string $FIELD_ESCAPE = '',
         public string $ENCODING = EncodingHelper::ENCODING_UTF8,
+        public string $FIELD_ESCAPE = '',
     ) {}
 }

--- a/src/Reader/CSV/RowIterator.php
+++ b/src/Reader/CSV/RowIterator.php
@@ -178,7 +178,7 @@ final class RowIterator implements RowIteratorInterface
             self::MAX_READ_BYTES_PER_LINE,
             $this->options->FIELD_DELIMITER,
             $this->options->FIELD_ENCLOSURE,
-            ''
+            $this->options->FIELD_ESCAPE,
         );
         if (false === $encodedRowData) {
             return false;

--- a/src/Writer/CSV/Options.php
+++ b/src/Writer/CSV/Options.php
@@ -18,8 +18,8 @@ final readonly class Options
     public function __construct(
         public string $FIELD_DELIMITER = ',',
         public string $FIELD_ENCLOSURE = '"',
-        public string $EOL = "\n",
         public bool $SHOULD_ADD_BOM = true,
         public int $FLUSH_THRESHOLD = 500,
+        public string $EOL = "\n",
     ) {}
 }

--- a/src/Writer/CSV/Options.php
+++ b/src/Writer/CSV/Options.php
@@ -7,6 +7,10 @@ namespace OpenSpout\Writer\CSV;
 final readonly class Options
 {
     /**
+     * Note: There is no FIELD_ESCAPE option for the writer because PHP's fputcsv()
+     * always escapes the enclosure character by doubling it, regardless of the
+     * escape parameter. FIELD_ESCAPE is only available on the reader Options.
+     *
      * @param non-empty-string $FIELD_DELIMITER
      * @param non-empty-string $FIELD_ENCLOSURE
      * @param positive-int     $FLUSH_THRESHOLD
@@ -14,6 +18,7 @@ final readonly class Options
     public function __construct(
         public string $FIELD_DELIMITER = ',',
         public string $FIELD_ENCLOSURE = '"',
+        public string $EOL = "\n",
         public bool $SHOULD_ADD_BOM = true,
         public int $FLUSH_THRESHOLD = 500,
     ) {}

--- a/src/Writer/CSV/Writer.php
+++ b/src/Writer/CSV/Writer.php
@@ -74,7 +74,8 @@ final class Writer extends AbstractWriter
             $cells,
             $this->options->FIELD_DELIMITER,
             $this->options->FIELD_ENCLOSURE,
-            ''
+            '',
+            $this->options->EOL,
         );
         if (false === $wasWriteSuccessful) {
             throw new IOException('Unable to write data'); // @codeCoverageIgnore

--- a/tests/Reader/CSV/ReaderTest.php
+++ b/tests/Reader/CSV/ReaderTest.php
@@ -179,6 +179,20 @@ final class ReaderTest extends TestCase
         self::assertSame([$expectedRow], $allRows);
     }
 
+    public function testReadShouldSupportCustomFieldEscape(): void
+    {
+        $allRows = $this->getAllRowsForFile(
+            'csv_with_backslash_escape.csv',
+            fieldEscape: '\\',
+        );
+
+        $expectedRows = [
+            ['csv--11', 'csv with \"quotes\"', 'csv--13'],
+            ['csv--21', 'csv--22', 'csv--23'],
+        ];
+        self::assertSame($expectedRows, $allRows);
+    }
+
     public function testReadShouldNotTruncateLineBreak(): void
     {
         $allRows = $this->getAllRowsForFile('csv_with_line_breaks.csv');
@@ -394,7 +408,8 @@ final class ReaderTest extends TestCase
         ?string $fieldDelimiter = null,
         ?string $fieldEnclosure = null,
         ?string $encoding = null,
-        ?bool $shouldPreserveEmptyRows = null
+        ?bool $shouldPreserveEmptyRows = null,
+        ?string $fieldEscape = null,
     ): array {
         $allRows = [];
         $resourcePath = TestUsingResource::getResourcePath($fileName);
@@ -405,6 +420,9 @@ final class ReaderTest extends TestCase
         }
         if (null !== $fieldEnclosure) {
             $options['FIELD_ENCLOSURE'] = $fieldEnclosure;
+        }
+        if (null !== $fieldEscape) {
+            $options['FIELD_ESCAPE'] = $fieldEscape;
         }
         if (null !== $encoding) {
             $options['ENCODING'] = $encoding;

--- a/tests/Writer/CSV/WriterTest.php
+++ b/tests/Writer/CSV/WriterTest.php
@@ -193,6 +193,32 @@ final class WriterTest extends TestCase
         self::assertSame('#This is, a comma#,csv--12,csv--13', $writtenContent, 'The fields should be enclosed with #');
     }
 
+    public function testWriteShouldSupportCrlfEol(): void
+    {
+        $allRows = [
+            Row::fromValues(['csv--11', 'csv--12']),
+            Row::fromValues(['csv--21', 'csv--22']),
+        ];
+        $options = new Options(
+            EOL: "\r\n",
+            SHOULD_ADD_BOM: false,
+        );
+        $writtenContent = $this->writeToCsvFileAndReturnWrittenContent($allRows, 'csv_with_crlf.csv', $options);
+
+        self::assertSame("csv--11,csv--12\r\ncsv--21,csv--22\r\n", $writtenContent);
+    }
+
+    public function testWriteShouldDefaultToLfEol(): void
+    {
+        $allRows = [
+            Row::fromValues(['csv--11', 'csv--12']),
+        ];
+        $options = new Options(SHOULD_ADD_BOM: false);
+        $writtenContent = $this->writeToCsvFileAndReturnWrittenContent($allRows, 'csv_with_lf.csv', $options);
+
+        self::assertSame("csv--11,csv--12\n", $writtenContent);
+    }
+
     public function testWriteShouldSupportedEscapedCharacters(): void
     {
         $allRows = [

--- a/tests/resources/csv/csv_with_backslash_escape.csv
+++ b/tests/resources/csv/csv_with_backslash_escape.csv
@@ -1,0 +1,2 @@
+"csv--11","csv with \"quotes\"","csv--13"
+"csv--21","csv--22","csv--23"


### PR DESCRIPTION
## Summary
- Add configurable `FIELD_ESCAPE` to `\OpenSpout\Reader\CSV\Options`, passed through to `fgetcsv()` (default `''` for backwards compatibility)
- Add configurable `EOL` to `\OpenSpout\Writer\CSV\Options`, passed through to `fputcsv()` (default `"\n"` for backwards compatibility), enabling RFC 4180 compliant CRLF output
- `FIELD_ESCAPE` is intentionally not exposed on the writer because PHP's `fputcsv()` always escapes the enclosure by doubling it, regardless of the escape parameter

## Test plan
- [x] New test `testReadShouldSupportCustomFieldEscape` with dedicated test resource
- [x] New tests `testWriteShouldSupportCrlfEol` and `testWriteShouldDefaultToLfEol`
- [x] All existing CSV reader and writer tests pass unchanged


See #366 for reference