### PR TITLE
Enforce sorted cell arrays

### DIFF
--- a/src/Common/Entity/Row.php
+++ b/src/Common/Entity/Row.php
@@ -21,6 +21,7 @@ final readonly class Row
         public array $cells,
         public float $height = self::DEFAULT_HEIGHT,
     ) {
+        $lastIndex = -1;
         foreach ($this->cells as $index => $cell) {
             if (!\is_int($index) || 0 > $index) {
                 throw new InvalidArgumentException(\sprintf(
@@ -36,6 +37,15 @@ final readonly class Row
                     $index
                 ));
             }
+            if ($index <= $lastIndex) {
+                // see https://github.com/openspout/openspout/issues/362 for details
+                throw new InvalidArgumentException(\sprintf(
+                    'Cell indexes must be in ascending order, index %s is not greater than previous index %s. Run `\ksort()` on the cell array.',
+                    $index,
+                    $lastIndex
+                ));
+            }
+            $lastIndex = $index;
         }
     }
 

--- a/tests/Common/Entity/RowTest.php
+++ b/tests/Common/Entity/RowTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenSpout\Common\Entity;
 
+use InvalidArgumentException;
 use OpenSpout\Common\Entity\Style\Style;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -80,5 +81,11 @@ final class RowTest extends TestCase
         $row = Row::fromValuesWithStyle(['a' => 1, 'b' => 2], $style);
 
         self::assertIsList($row->cells);
+    }
+
+    public function testDoesNotAcceptUnsortedCellArraysInConstructor(): void
+    {
+        self::expectException(InvalidArgumentException::class);
+        new Row([1 => Cell::fromValue('foo'), 0 => Cell::fromValue('bar')]);
     }
 }


### PR DESCRIPTION
This PR resolves #362 by warning about invalid cell arrays.

This implementation does not sort the keys as we do not want to take a hit on memory usage or performance.
Instead we raise an exception if the keys of `$cells` given to `Row` are not sorted.

The error message mentions `ksort` to lead affected users to a fast fix if they hit this exception.