### PR TITLE
Updated to Validation\CellReference to allow for absolute ranges and references to other sheets.

### DIFF
--- a/src/Writer/XLSX/Validation/CellReference.php
+++ b/src/Writer/XLSX/Validation/CellReference.php
@@ -19,7 +19,9 @@ final readonly class CellReference
         public int $fromColumnIndex,
         public int $fromRow,
         public int $toColumnIndex,
-        public int $toRow
+        public int $toRow,
+        public bool $absolute = true,
+        public ?string $sheetName = null,
     ) {
         if ($this->fromRow > $this->toRow || $this->fromColumnIndex > $this->toColumnIndex) {
             throw new InvalidArgumentException('Top-left cell must not be below or to the right of bottom-right cell.');
@@ -28,12 +30,26 @@ final readonly class CellReference
 
     public function serialize(): string
     {
-        return \sprintf(
-            '%s%s:%s%s',
+        $prefix = $this->absolute ? '$' : '';
+
+        $reference = \sprintf(
+            '%s%s%s:%s%s%s',
+            $prefix,
             CellHelper::getColumnLettersFromColumnIndex($this->fromColumnIndex),
-            $this->fromRow,
+            $prefix.$this->fromRow,
+            $prefix,
             CellHelper::getColumnLettersFromColumnIndex($this->toColumnIndex),
-            $this->toRow,
+            $prefix.$this->toRow,
         );
+
+        if (null !== $this->sheetName) {
+            $escapedSheet = str_contains($this->sheetName, ' ')
+                ? "'".$this->sheetName."'"
+                : $this->sheetName;
+
+            return $escapedSheet.'!'.$reference;
+        }
+
+        return $reference;
     }
 }

--- a/tests/Writer/XLSX/Validation/CellReferenceTest.php
+++ b/tests/Writer/XLSX/Validation/CellReferenceTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Writer\XLSX\Validation;
+
+use InvalidArgumentException;
+use OpenSpout\Writer\XLSX\Validation\CellReference;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class CellReferenceTest extends TestCase
+{
+	public function testAbsoluteSingleCell(): void
+	{
+		$ref = new CellReference(0, 1, 0, 1);
+
+		self::assertSame('$A$1:$A$1', $ref->serialize());
+	}
+
+	public function testAbsoluteRange(): void
+	{
+		$ref = new CellReference(0, 1, 2, 10);
+
+		self::assertSame('$A$1:$C$10', $ref->serialize());
+	}
+
+		public function testRelativeSingleCell(): void
+	{
+		$ref = new CellReference(0, 1, 0, 1, absolute: false);
+
+		self::assertSame('A1:A1', $ref->serialize());
+	}
+
+	public function testRelativeRange(): void
+	{
+		$ref = new CellReference(0, 1, 2, 10, absolute: false);
+
+		self::assertSame('A1:C10', $ref->serialize());
+	}
+
+	public function testAbsoluteWithSheetName(): void
+	{
+		$ref = new CellReference(0, 1, 0, 10, sheetName: 'Sheet1');
+
+		self::assertSame('Sheet1!$A$1:$A$10', $ref->serialize());
+	}
+
+	public function testRelativeWithSheetName(): void
+	{
+		$ref = new CellReference(0, 1, 0, 10, absolute: false, sheetName: 'Sheet1');
+
+		self::assertSame('Sheet1!A1:A10', $ref->serialize());
+	}
+
+	public function testSheetNameWithSpacesIsQuoted(): void
+	{
+		$ref = new CellReference(0, 1, 0, 10, sheetName: 'Lookup Data');
+
+		self::assertSame("'Lookup Data'!\$A\$1:\$A\$10", $ref->serialize());
+	}
+
+	public function testMultiLetterColumn(): void
+	{
+		$ref = new CellReference(26, 1, 26, 1);
+
+		self::assertSame('$AA$1:$AA$1', $ref->serialize());
+	}
+
+	public function testInvertedRowsThrows(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+
+		new CellReference(0, 10, 0, 1);
+	}
+
+	public function testInvertedColumnsThrows(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+
+		new CellReference(5, 1, 2, 10);
+	}
+}

--- a/tests/Writer/XLSX/Validation/CellReferenceTest.php
+++ b/tests/Writer/XLSX/Validation/CellReferenceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Writer\XLSX\Validation;
 
 use InvalidArgumentException;
@@ -11,73 +13,73 @@ use PHPUnit\Framework\TestCase;
  */
 final class CellReferenceTest extends TestCase
 {
-	public function testAbsoluteSingleCell(): void
-	{
-		$ref = new CellReference(0, 1, 0, 1);
+    public function testAbsoluteSingleCell(): void
+    {
+        $ref = new CellReference(0, 1, 0, 1);
 
-		self::assertSame('$A$1:$A$1', $ref->serialize());
-	}
+        self::assertSame('$A$1:$A$1', $ref->serialize());
+    }
 
-	public function testAbsoluteRange(): void
-	{
-		$ref = new CellReference(0, 1, 2, 10);
+    public function testAbsoluteRange(): void
+    {
+        $ref = new CellReference(0, 1, 2, 10);
 
-		self::assertSame('$A$1:$C$10', $ref->serialize());
-	}
+        self::assertSame('$A$1:$C$10', $ref->serialize());
+    }
 
-		public function testRelativeSingleCell(): void
-	{
-		$ref = new CellReference(0, 1, 0, 1, absolute: false);
+    public function testRelativeSingleCell(): void
+    {
+        $ref = new CellReference(0, 1, 0, 1, absolute: false);
 
-		self::assertSame('A1:A1', $ref->serialize());
-	}
+        self::assertSame('A1:A1', $ref->serialize());
+    }
 
-	public function testRelativeRange(): void
-	{
-		$ref = new CellReference(0, 1, 2, 10, absolute: false);
+    public function testRelativeRange(): void
+    {
+        $ref = new CellReference(0, 1, 2, 10, absolute: false);
 
-		self::assertSame('A1:C10', $ref->serialize());
-	}
+        self::assertSame('A1:C10', $ref->serialize());
+    }
 
-	public function testAbsoluteWithSheetName(): void
-	{
-		$ref = new CellReference(0, 1, 0, 10, sheetName: 'Sheet1');
+    public function testAbsoluteWithSheetName(): void
+    {
+        $ref = new CellReference(0, 1, 0, 10, sheetName: 'Sheet1');
 
-		self::assertSame('Sheet1!$A$1:$A$10', $ref->serialize());
-	}
+        self::assertSame('Sheet1!$A$1:$A$10', $ref->serialize());
+    }
 
-	public function testRelativeWithSheetName(): void
-	{
-		$ref = new CellReference(0, 1, 0, 10, absolute: false, sheetName: 'Sheet1');
+    public function testRelativeWithSheetName(): void
+    {
+        $ref = new CellReference(0, 1, 0, 10, absolute: false, sheetName: 'Sheet1');
 
-		self::assertSame('Sheet1!A1:A10', $ref->serialize());
-	}
+        self::assertSame('Sheet1!A1:A10', $ref->serialize());
+    }
 
-	public function testSheetNameWithSpacesIsQuoted(): void
-	{
-		$ref = new CellReference(0, 1, 0, 10, sheetName: 'Lookup Data');
+    public function testSheetNameWithSpacesIsQuoted(): void
+    {
+        $ref = new CellReference(0, 1, 0, 10, sheetName: 'Lookup Data');
 
-		self::assertSame("'Lookup Data'!\$A\$1:\$A\$10", $ref->serialize());
-	}
+        self::assertSame("'Lookup Data'!\$A\$1:\$A\$10", $ref->serialize());
+    }
 
-	public function testMultiLetterColumn(): void
-	{
-		$ref = new CellReference(26, 1, 26, 1);
+    public function testMultiLetterColumn(): void
+    {
+        $ref = new CellReference(26, 1, 26, 1);
 
-		self::assertSame('$AA$1:$AA$1', $ref->serialize());
-	}
+        self::assertSame('$AA$1:$AA$1', $ref->serialize());
+    }
 
-	public function testInvertedRowsThrows(): void
-	{
-		$this->expectException(InvalidArgumentException::class);
+    public function testInvertedRowsThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
 
-		new CellReference(0, 10, 0, 1);
-	}
+        new CellReference(0, 10, 0, 1);
+    }
 
-	public function testInvertedColumnsThrows(): void
-	{
-		$this->expectException(InvalidArgumentException::class);
+    public function testInvertedColumnsThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
 
-		new CellReference(5, 1, 2, 10);
-	}
+        new CellReference(5, 1, 2, 10);
+    }
 }

--- a/tests/Writer/XLSX/Validation/Rules/DateValidationRuleTest.php
+++ b/tests/Writer/XLSX/Validation/Rules/DateValidationRuleTest.php
@@ -38,6 +38,6 @@ final class DateValidationRuleTest extends TestCase
         $serialized_validation_rule = $rule->serialize();
 
         self::assertSame('date', $serialized_validation_rule->type);
-        self::assertSame('A1:A1', $serialized_validation_rule->formula1);
+        self::assertSame('$A$1:$A$1', $serialized_validation_rule->formula1);
     }
 }

--- a/tests/Writer/XLSX/Validation/Rules/DecimalValidationRuleTest.php
+++ b/tests/Writer/XLSX/Validation/Rules/DecimalValidationRuleTest.php
@@ -25,8 +25,8 @@ final class DecimalValidationRuleTest extends TestCase
 
         self::assertSame('decimal', $serialized_validation_rule->type);
         self::assertSame('between', $serialized_validation_rule->operator);
-        self::assertSame('A1:A1', $serialized_validation_rule->formula1);
-        self::assertSame('A2:A2', $serialized_validation_rule->formula2);
+        self::assertSame('$A$1:$A$1', $serialized_validation_rule->formula1);
+        self::assertSame('$A$2:$A$2', $serialized_validation_rule->formula2);
     }
 
     public function testDecimalsAreConvertedToStrings(): void

--- a/tests/Writer/XLSX/Validation/Rules/ListValidationRuleTest.php
+++ b/tests/Writer/XLSX/Validation/Rules/ListValidationRuleTest.php
@@ -45,7 +45,7 @@ final class ListValidationRuleTest extends TestCase
         $serialized_validation_rule = $rule->serialize();
 
         self::assertSame('list', $serialized_validation_rule->type);
-        self::assertSame('A1:A10', $serialized_validation_rule->formula1);
+        self::assertSame('$A$1:$A$10', $serialized_validation_rule->formula1);
     }
 
     public function testSerializeWithSingleCellReference(): void
@@ -54,6 +54,6 @@ final class ListValidationRuleTest extends TestCase
         $rule = new ListValidationRule($cellRef);
         $serialized_validation_rule = $rule->serialize();
 
-        self::assertSame('F5:F5', $serialized_validation_rule->formula1);
+        self::assertSame('$F$5:$F$5', $serialized_validation_rule->formula1);
     }
 }

--- a/tests/Writer/XLSX/Validation/Rules/TextLengthValidationRuleTest.php
+++ b/tests/Writer/XLSX/Validation/Rules/TextLengthValidationRuleTest.php
@@ -34,7 +34,7 @@ final class TextLengthValidationRuleTest extends TestCase
         $serialized_validation_rule = $rule->serialize();
 
         self::assertSame('textLength', $serialized_validation_rule->type);
-        self::assertSame('A1:A1', $serialized_validation_rule->formula1);
+        self::assertSame('$A$1:$A$1', $serialized_validation_rule->formula1);
         self::assertNull($serialized_validation_rule->formula2);
     }
 }

--- a/tests/Writer/XLSX/Validation/Rules/TimeValidationRuleTest.php
+++ b/tests/Writer/XLSX/Validation/Rules/TimeValidationRuleTest.php
@@ -59,6 +59,6 @@ final class TimeValidationRuleTest extends TestCase
         $serialized_validation_rule = $rule->serialize();
 
         self::assertSame('date', $serialized_validation_rule->type);
-        self::assertSame('A1:A1', $serialized_validation_rule->formula1);
+        self::assertSame('$A$1:$A$1', $serialized_validation_rule->formula1);
     }
 }

--- a/tests/Writer/XLSX/Validation/Rules/WholeNumberValidationRuleTest.php
+++ b/tests/Writer/XLSX/Validation/Rules/WholeNumberValidationRuleTest.php
@@ -36,8 +36,8 @@ final class WholeNumberValidationRuleTest extends TestCase
         $serialized_validation_rule = $rule->serialize();
 
         self::assertSame('whole', $serialized_validation_rule->type);
-        self::assertSame('A1:A1', $serialized_validation_rule->formula1);
-        self::assertSame('B1:B1', $serialized_validation_rule->formula2);
+        self::assertSame('$A$1:$A$1', $serialized_validation_rule->formula1);
+        self::assertSame('$B$1:$B$1', $serialized_validation_rule->formula2);
     }
 
     public function testWholeNumberWithoutSecondValue(): void

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -1437,15 +1437,15 @@ final class WriterTest extends TestCase
         self::assertNotFalse($sheet1XmlContents);
         self::assertStringContainsString('<dataValidations', $sheet1XmlContents, 'Sheet 1 should have data validations');
         self::assertStringContainsString('type="list"', $sheet1XmlContents, 'Sheet 1 should have a list validation');
-        self::assertStringContainsString('A2:A10', $sheet1XmlContents, 'Sheet 1 should reference column A');
-        self::assertStringNotContainsString('B2:B10"', $sheet1XmlContents, 'Sheet 1 should not reference sheet 2 range');
+        self::assertStringContainsString('$A$2:$A$10', $sheet1XmlContents, 'Sheet 1 should reference column A');
+        self::assertStringNotContainsString('$B$2:$B$10"', $sheet1XmlContents, 'Sheet 1 should not reference sheet 2 range');
 
         $sheet2XmlContents = file_get_contents('zip://'.$resourcePath.'#xl/worksheets/sheet2.xml');
         self::assertNotFalse($sheet2XmlContents);
         self::assertStringContainsString('<dataValidations', $sheet2XmlContents, 'Sheet 2 should have data validations');
         self::assertStringContainsString('type="list"', $sheet2XmlContents, 'Sheet 2 should have a list validation');
-        self::assertStringContainsString('B2:B10', $sheet2XmlContents, 'Sheet 2 should reference column B');
-        self::assertStringNotContainsString('A2:A10"', $sheet2XmlContents, 'Sheet 2 should not reference sheet 1 range');
+        self::assertStringContainsString('$B$2:$B$10', $sheet2XmlContents, 'Sheet 2 should reference column B');
+        self::assertStringNotContainsString('$A$2:$A$10"', $sheet2XmlContents, 'Sheet 2 should not reference sheet 1 range');
     }
 
     /**


### PR DESCRIPTION
While I was testing the new Validation implementation, I was missing two things.

Firstly the CellReference class used relative ranges, which was not what I expected. 

Secondly, I was missing an option to reference cells on another sheet.

I have add both functionalities in this PR. 

I can still use the current implementation for my use case, so this has no urgency to merge. I thought other user could use this too. 