### PR TITLE
Fix: allow cell to have different style per border position

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -156,9 +156,3 @@ parameters:
 			count: 1
 			path: tests/Writer/ODS/Manager/Style/StyleRegistryTest.php
 
-		-
-			message: '#^Readonly property OpenSpout\\Writer\\Common\\AbstractOptions\:\:\$SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY is assigned outside of its declaring class\.$#'
-			identifier: property.readOnlyAssignOutOfClass
-			count: 1
-			path: tests/Writer/ODS/WriterTest.php
-

--- a/src/Common/Entity/Style/Style.php
+++ b/src/Common/Entity/Style/Style.php
@@ -167,7 +167,18 @@ final readonly class Style
     {
         $values = get_object_vars($this);
         unset($values['shouldApplyFont']);
-        $values['border'] = $border;
+
+        if ($this->border !== null) {
+            $mergedParts = $this->border->getParts();
+
+            foreach ($border->getParts() as $part) {
+                $mergedParts[$part->name->value] = $part;
+            }
+
+            $values['border'] = new Border(...array_values($mergedParts));
+        } else {
+            $values['border'] = $border;
+        }
 
         return new self(...$values);
     }

--- a/src/Common/Entity/Style/Style.php
+++ b/src/Common/Entity/Style/Style.php
@@ -168,7 +168,7 @@ final readonly class Style
         $values = get_object_vars($this);
         unset($values['shouldApplyFont']);
 
-        if ($this->border !== null) {
+        if (null !== $this->border) {
             $mergedParts = $this->border->getParts();
 
             foreach ($border->getParts() as $part) {

--- a/tests/Common/Entity/Style/BorderTest.php
+++ b/tests/Common/Entity/Style/BorderTest.php
@@ -95,12 +95,14 @@ final class BorderTest extends TestCase
         self::assertNotNull($newBorder->getPart(BorderName::TOP));
         self::assertCount(1, $border->getParts());
     }
+
     public function testShouldAllowDefiningMultipleSpecificBorders(): void
     {
         $border = new Border(
             new BorderPart(BorderName::TOP, Color::BLACK, BorderWidth::THICK),
             new BorderPart(BorderName::BOTTOM, Color::RED, BorderWidth::THICK)
         );
+
         self::assertCount(2, $border->getParts(), 'Border should have exactly 2 parts');
         self::assertSame(Color::BLACK, $border->getPart(BorderName::TOP)?->color);
         self::assertSame(Color::RED, $border->getPart(BorderName::BOTTOM)?->color);

--- a/tests/Common/Entity/Style/BorderTest.php
+++ b/tests/Common/Entity/Style/BorderTest.php
@@ -95,4 +95,14 @@ final class BorderTest extends TestCase
         self::assertNotNull($newBorder->getPart(BorderName::TOP));
         self::assertCount(1, $border->getParts());
     }
+    public function testShouldAllowDefiningMultipleSpecificBorders(): void
+    {
+        $border = new Border(
+            new BorderPart(BorderName::TOP, Color::BLACK, BorderWidth::THICK),
+            new BorderPart(BorderName::BOTTOM, Color::RED, BorderWidth::THICK)
+        );
+        self::assertCount(2, $border->getParts(), 'Border should have exactly 2 parts');
+        self::assertSame(Color::BLACK, $border->getPart(BorderName::TOP)?->color);
+        self::assertSame(Color::RED, $border->getPart(BorderName::BOTTOM)?->color);
+    }
 }

--- a/tests/Writer/ODS/WriterTest.php
+++ b/tests/Writer/ODS/WriterTest.php
@@ -521,11 +521,15 @@ final class WriterTest extends TestCase
     ): Writer {
         $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
 
-        $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
+        $optionsArray = [
+            'tempFolder' => (new TestUsingResource())->getTempFolderPath(),
+        ];
+
         if (null !== $shouldCreateSheetsAutomatically) {
-            $options->SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY = $shouldCreateSheetsAutomatically;
+            $optionsArray['SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY'] = $shouldCreateSheetsAutomatically;
         }
-        $writer = new Writer($options);
+
+        $writer = new Writer(new Options(...$optionsArray));
 
         $writer->openToFile($resourcePath);
         $writer->addRows($allRows);


### PR DESCRIPTION
This PR implements the missing border parts for cells (top, bottom, stroke) as discussed in issue #108.