### PR TITLE
Xlsx images

### DIFF
--- a/src/Common/Entity/Cell.php
+++ b/src/Common/Entity/Cell.php
@@ -73,7 +73,7 @@ abstract readonly class Cell
         return new StringCell($value, $style, $comment, $hyperlinkUrl);
     }
 
-    final public static function fromImageFile(
+    final public static function fromImagePath(
         string $path,
         int $width,
         int $height,

--- a/src/Common/Entity/Cell.php
+++ b/src/Common/Entity/Cell.php
@@ -72,15 +72,4 @@ abstract readonly class Cell
 
         return new StringCell($value, $style, $comment, $hyperlinkUrl);
     }
-
-    final public static function fromImagePath(
-        string $path,
-        int $width,
-        int $height,
-        ?Style $style = null,
-        ?Comment $comment = null,
-        bool $fitToCell = false,
-    ): self {
-        return new ImageCell($path, $width, $height, $style, $comment, $fitToCell);
-    }
 }

--- a/src/Common/Entity/Cell.php
+++ b/src/Common/Entity/Cell.php
@@ -11,6 +11,7 @@ use OpenSpout\Common\Entity\Cell\DateIntervalCell;
 use OpenSpout\Common\Entity\Cell\DateTimeCell;
 use OpenSpout\Common\Entity\Cell\EmptyCell;
 use OpenSpout\Common\Entity\Cell\FormulaCell;
+use OpenSpout\Common\Entity\Cell\ImageCell;
 use OpenSpout\Common\Entity\Cell\NumericCell;
 use OpenSpout\Common\Entity\Cell\StringCell;
 use OpenSpout\Common\Entity\Cell\TextRunCell;
@@ -69,5 +70,14 @@ abstract readonly class Cell
         }
 
         return new StringCell($value, $style, $comment);
+    }
+
+    final public static function fromFile(
+        string $path,
+        ?Style $style = null,
+        ?Comment $comment = null,
+        bool $fitToCell = false,
+    ): self {
+        return new ImageCell($path, $style, $comment, $fitToCell);
     }
 }

--- a/src/Common/Entity/Cell.php
+++ b/src/Common/Entity/Cell.php
@@ -75,10 +75,12 @@ abstract readonly class Cell
 
     final public static function fromImageFile(
         string $path,
+        int $width,
+        int $height,
         ?Style $style = null,
         ?Comment $comment = null,
         bool $fitToCell = false,
     ): self {
-        return new ImageCell($path, $style, $comment, $fitToCell);
+        return new ImageCell($path, $width, $height, $style, $comment, $fitToCell);
     }
 }

--- a/src/Common/Entity/Cell.php
+++ b/src/Common/Entity/Cell.php
@@ -11,7 +11,6 @@ use OpenSpout\Common\Entity\Cell\DateIntervalCell;
 use OpenSpout\Common\Entity\Cell\DateTimeCell;
 use OpenSpout\Common\Entity\Cell\EmptyCell;
 use OpenSpout\Common\Entity\Cell\FormulaCell;
-use OpenSpout\Common\Entity\Cell\ImageCell;
 use OpenSpout\Common\Entity\Cell\NumericCell;
 use OpenSpout\Common\Entity\Cell\StringCell;
 use OpenSpout\Common\Entity\Cell\TextRunCell;

--- a/src/Common/Entity/Cell.php
+++ b/src/Common/Entity/Cell.php
@@ -73,7 +73,7 @@ abstract readonly class Cell
         return new StringCell($value, $style, $comment, $hyperlinkUrl);
     }
 
-    final public static function fromFile(
+    final public static function fromImageFile(
         string $path,
         ?Style $style = null,
         ?Comment $comment = null,

--- a/src/Common/Entity/Cell/ImageCell.php
+++ b/src/Common/Entity/Cell/ImageCell.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSpout\Common\Entity\Cell;
+
+use OpenSpout\Common\Entity\Cell;
+use OpenSpout\Common\Entity\Comment\Comment;
+use OpenSpout\Common\Entity\Style\Style;
+use OpenSpout\Common\Exception\InvalidArgumentException;
+use OpenSpout\Common\Exception\UnsupportedTypeException;
+
+final readonly class ImageCell extends Cell
+{
+    public int $width;
+    public int $height;
+    public string $mimeType;
+
+    public function __construct(
+        private string $path,
+        ?Style $style = null,
+        ?Comment $comment = null,
+    ) {
+        if (!\extension_loaded('imagick') && !\extension_loaded('gd')) {
+            throw new UnsupportedTypeException('Neither the imagick nor gd PHP extension is available.');
+        }
+
+        if (!file_exists($path)) {
+            throw new InvalidArgumentException("Image file not found: {$path}");
+        }
+
+        [$this->width, $this->height, $this->mimeType] = self::getImageInfo($path);
+
+        parent::__construct($style, $comment);
+    }
+
+    public function getValue(): string
+    {
+        return $this->path;
+    }
+
+    public function getExtension(): string
+    {
+        return match ($this->mimeType) {
+            'image/jpeg' => 'jpeg',
+            'image/gif' => 'gif',
+            'image/bmp' => 'bmp',
+            'image/webp' => 'webp',
+            default => 'png',
+        };
+    }
+
+    public function withStyle(Style $style): static
+    {
+        return new self($this->path, $style, $this->comment);
+    }
+
+    public function withoutStyle(): static
+    {
+        return new self($this->path, null, $this->comment);
+    }
+
+    public function withComment(Comment $comment): static
+    {
+        return new self($this->path, $this->style, $comment);
+    }
+
+    public function withoutComment(): static
+    {
+        return new self($this->path, $this->style, null);
+    }
+
+    /**
+     * @return array{int, int, string} [width, height, mimeType]
+     */
+    private static function getImageInfo(string $path): array
+    {
+        if (\extension_loaded('imagick')) {
+            $imagick = new \Imagick($path);
+            $width = $imagick->getImageWidth();
+            $height = $imagick->getImageHeight();
+            $format = strtolower($imagick->getImageFormat());
+            $imagick->clear();
+            $mimeType = match ($format) {
+                'jpg', 'jpeg' => 'image/jpeg',
+                'gif' => 'image/gif',
+                'bmp' => 'image/bmp',
+                'webp' => 'image/webp',
+                default => 'image/png',
+            };
+
+            return [$width, $height, $mimeType];
+        }
+
+        $info = getimagesize($path);
+        if (false === $info) {
+            throw new InvalidArgumentException("Could not read image info for: {$path}");
+        }
+
+        return [$info[0], $info[1], $info['mime']];
+    }
+}

--- a/src/Common/Entity/Cell/ImageCell.php
+++ b/src/Common/Entity/Cell/ImageCell.php
@@ -20,6 +20,7 @@ final readonly class ImageCell extends Cell
         private string $path,
         ?Style $style = null,
         ?Comment $comment = null,
+        public bool $fitToCell = false,
     ) {
         if (!\extension_loaded('imagick') && !\extension_loaded('gd')) {
             throw new UnsupportedTypeException('Neither the imagick nor gd PHP extension is available.');
@@ -50,29 +51,32 @@ final readonly class ImageCell extends Cell
         };
     }
 
+    public function withFitToCell(bool $fitToCell): self
+    {
+        return new self($this->path, $this->style, $this->comment, $fitToCell);
+    }
+
     public function withStyle(Style $style): static
     {
-        return new self($this->path, $style, $this->comment);
+        return new self($this->path, $style, $this->comment, $this->fitToCell);
     }
 
     public function withoutStyle(): static
     {
-        return new self($this->path, null, $this->comment);
+        return new self($this->path, null, $this->comment, $this->fitToCell);
     }
 
     public function withComment(Comment $comment): static
     {
-        return new self($this->path, $this->style, $comment);
+        return new self($this->path, $this->style, $comment, $this->fitToCell);
     }
 
     public function withoutComment(): static
     {
-        return new self($this->path, $this->style, null);
+        return new self($this->path, $this->style, null, $this->fitToCell);
     }
 
-    /**
-     * @return array{int, int, string} [width, height, mimeType]
-     */
+    /** @return array{int, int, string} [width, height, mimeType] */
     private static function getImageInfo(string $path): array
     {
         if (\extension_loaded('imagick')) {

--- a/src/Common/Entity/Cell/ImageCell.php
+++ b/src/Common/Entity/Cell/ImageCell.php
@@ -8,6 +8,7 @@ use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Common\Entity\Comment\Comment;
 use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Common\Exception\InvalidArgumentException;
+use OpenSpout\Common\Exception\UnsupportedImageTypeException;
 use OpenSpout\Common\Exception\UnsupportedTypeException;
 
 final readonly class ImageCell extends Cell
@@ -40,14 +41,18 @@ final readonly class ImageCell extends Cell
         return $this->path;
     }
 
+    /**
+     * @throws UnsupportedImageTypeException
+     */
     public function getExtension(): string
     {
         return match ($this->mimeType) {
             'image/jpeg' => 'jpeg',
+            'image/png' => 'png',
             'image/gif' => 'gif',
             'image/bmp' => 'bmp',
             'image/webp' => 'webp',
-            default => 'png',
+            default => throw new UnsupportedImageTypeException("Unsupported image MIME type: {$this->mimeType}"),
         };
     }
 
@@ -76,7 +81,10 @@ final readonly class ImageCell extends Cell
         return new self($this->path, $this->style, null, $this->fitToCell);
     }
 
-    /** @return array{int, int, string} [width, height, mimeType] */
+    /**
+     * @return array{int, int, string} [width, height, mimeType]
+     * @throws UnsupportedImageTypeException
+     */
     private static function getImageInfo(string $path): array
     {
         if (\extension_loaded('imagick')) {
@@ -87,10 +95,11 @@ final readonly class ImageCell extends Cell
             $imagick->clear();
             $mimeType = match ($format) {
                 'jpg', 'jpeg' => 'image/jpeg',
+                'png' => 'image/png',
                 'gif' => 'image/gif',
                 'bmp' => 'image/bmp',
                 'webp' => 'image/webp',
-                default => 'image/png',
+                default => throw new UnsupportedImageTypeException("Unsupported image format: $format")
             };
 
             return [$width, $height, $mimeType];

--- a/src/Common/Entity/Cell/ImageCell.php
+++ b/src/Common/Entity/Cell/ImageCell.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenSpout\Common\Entity\Cell;
 
+use Imagick;
 use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Common\Entity\Comment\Comment;
 use OpenSpout\Common\Entity\Style\Style;
@@ -83,12 +84,13 @@ final readonly class ImageCell extends Cell
 
     /**
      * @return array{int, int, string} [width, height, mimeType]
+     *
      * @throws UnsupportedImageTypeException
      */
     private static function getImageInfo(string $path): array
     {
         if (\extension_loaded('imagick')) {
-            $imagick = new \Imagick($path);
+            $imagick = new Imagick($path);
             $width = $imagick->getImageWidth();
             $height = $imagick->getImageHeight();
             $format = strtolower($imagick->getImageFormat());
@@ -99,7 +101,7 @@ final readonly class ImageCell extends Cell
                 'gif' => 'image/gif',
                 'bmp' => 'image/bmp',
                 'webp' => 'image/webp',
-                default => throw new UnsupportedImageTypeException("Unsupported image format: $format")
+                default => throw new UnsupportedImageTypeException("Unsupported image format: {$format}")
             };
 
             return [$width, $height, $mimeType];

--- a/src/Common/Entity/Cell/ImageCell.php
+++ b/src/Common/Entity/Cell/ImageCell.php
@@ -26,7 +26,7 @@ final readonly class ImageCell extends Cell
             throw new InvalidArgumentException("Image file not found: {$path}");
         }
 
-        $ext = strtolower(pathinfo($path, \PATHINFO_EXTENSION));
+        $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
         $this->mimeType = match ($ext) {
             'jpg', 'jpeg' => 'image/jpeg',
             'png' => 'image/png',

--- a/src/Common/Entity/Cell/ImageCell.php
+++ b/src/Common/Entity/Cell/ImageCell.php
@@ -4,35 +4,37 @@ declare(strict_types=1);
 
 namespace OpenSpout\Common\Entity\Cell;
 
-use Imagick;
 use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Common\Entity\Comment\Comment;
 use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Common\Exception\InvalidArgumentException;
 use OpenSpout\Common\Exception\UnsupportedImageTypeException;
-use OpenSpout\Common\Exception\UnsupportedTypeException;
 
 final readonly class ImageCell extends Cell
 {
-    public int $width;
-    public int $height;
     public string $mimeType;
 
     public function __construct(
         private string $path,
+        public int $width,
+        public int $height,
         ?Style $style = null,
         ?Comment $comment = null,
         public bool $fitToCell = false,
     ) {
-        if (!\extension_loaded('imagick') && !\extension_loaded('gd')) {
-            throw new UnsupportedTypeException('Neither the imagick nor gd PHP extension is available.');
-        }
-
         if (!file_exists($path)) {
             throw new InvalidArgumentException("Image file not found: {$path}");
         }
 
-        [$this->width, $this->height, $this->mimeType] = self::getImageInfo($path);
+        $ext = strtolower(pathinfo($path, \PATHINFO_EXTENSION));
+        $this->mimeType = match ($ext) {
+            'jpg', 'jpeg' => 'image/jpeg',
+            'png' => 'image/png',
+            'gif' => 'image/gif',
+            'bmp' => 'image/bmp',
+            'webp' => 'image/webp',
+            default => throw new UnsupportedImageTypeException("Unsupported image type: .{$ext}"),
+        };
 
         parent::__construct($style, $comment);
     }
@@ -42,9 +44,6 @@ final readonly class ImageCell extends Cell
         return $this->path;
     }
 
-    /**
-     * @throws UnsupportedImageTypeException
-     */
     public function getExtension(): string
     {
         return match ($this->mimeType) {
@@ -53,65 +52,31 @@ final readonly class ImageCell extends Cell
             'image/gif' => 'gif',
             'image/bmp' => 'bmp',
             'image/webp' => 'webp',
-            default => throw new UnsupportedImageTypeException("Unsupported image MIME type: {$this->mimeType}"),
         };
     }
 
     public function withFitToCell(bool $fitToCell): self
     {
-        return new self($this->path, $this->style, $this->comment, $fitToCell);
+        return new self($this->path, $this->width, $this->height, $this->style, $this->comment, $fitToCell);
     }
 
     public function withStyle(Style $style): static
     {
-        return new self($this->path, $style, $this->comment, $this->fitToCell);
+        return new self($this->path, $this->width, $this->height, $style, $this->comment, $this->fitToCell);
     }
 
     public function withoutStyle(): static
     {
-        return new self($this->path, null, $this->comment, $this->fitToCell);
+        return new self($this->path, $this->width, $this->height, null, $this->comment, $this->fitToCell);
     }
 
     public function withComment(Comment $comment): static
     {
-        return new self($this->path, $this->style, $comment, $this->fitToCell);
+        return new self($this->path, $this->width, $this->height, $this->style, $comment, $this->fitToCell);
     }
 
     public function withoutComment(): static
     {
-        return new self($this->path, $this->style, null, $this->fitToCell);
-    }
-
-    /**
-     * @return array{int, int, string} [width, height, mimeType]
-     *
-     * @throws UnsupportedImageTypeException
-     */
-    private static function getImageInfo(string $path): array
-    {
-        if (\extension_loaded('imagick')) {
-            $imagick = new Imagick($path);
-            $width = $imagick->getImageWidth();
-            $height = $imagick->getImageHeight();
-            $format = strtolower($imagick->getImageFormat());
-            $imagick->clear();
-            $mimeType = match ($format) {
-                'jpg', 'jpeg' => 'image/jpeg',
-                'png' => 'image/png',
-                'gif' => 'image/gif',
-                'bmp' => 'image/bmp',
-                'webp' => 'image/webp',
-                default => throw new UnsupportedImageTypeException("Unsupported image format: {$format}")
-            };
-
-            return [$width, $height, $mimeType];
-        }
-
-        $info = getimagesize($path);
-        if (false === $info) {
-            throw new InvalidArgumentException("Could not read image info for: {$path}");
-        }
-
-        return [$info[0], $info[1], $info['mime']];
+        return new self($this->path, $this->width, $this->height, $this->style, null, $this->fitToCell);
     }
 }

--- a/src/Common/Exception/UnsupportedImageTypeException.php
+++ b/src/Common/Exception/UnsupportedImageTypeException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSpout\Common\Exception;
+
+final class UnsupportedImageTypeException extends OpenSpoutException {}

--- a/src/Writer/CSV/Writer.php
+++ b/src/Writer/CSV/Writer.php
@@ -8,6 +8,7 @@ use Exception;
 use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Common\Entity\Row;
 use OpenSpout\Common\Exception\IOException;
+use OpenSpout\Common\Exception\UnsupportedTypeException;
 use OpenSpout\Common\Helper\EncodingHelper;
 use OpenSpout\Writer\AbstractWriter;
 
@@ -55,6 +56,12 @@ final class Writer extends AbstractWriter
      */
     protected function addRowToWriter(Row $row): void
     {
+        foreach ($row->cells as $cell) {
+            if ($cell instanceof Cell\ImageCell) {
+                throw new UnsupportedTypeException('ImageCell is not supported in CSV format.');
+            }
+        }
+
         $cells = array_map(static function (Cell\BooleanCell|Cell\DateIntervalCell|Cell\DateTimeCell|Cell\EmptyCell|Cell\FormulaCell|Cell\NumericCell|Cell\StringCell $value): string {
             if ($value instanceof Cell\BooleanCell) {
                 return (string) (int) $value->getValue();

--- a/src/Writer/Common/Entity/Worksheet.php
+++ b/src/Writer/Common/Entity/Worksheet.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OpenSpout\Writer\Common\Entity;
 
+use OpenSpout\Common\Entity\Cell\ImageCell;
+
 /**
  * Entity describing a Worksheet.
  */
@@ -23,6 +25,9 @@ final class Worksheet
 
     /** @var int Index of the last written row */
     private int $lastWrittenRowIndex = 0;
+
+    /** @var array<array{row: int, col: int, cell: ImageCell}> */
+    private array $images = [];
 
     /**
      * Worksheet constructor.
@@ -79,6 +84,17 @@ final class Worksheet
     public function setLastWrittenRowIndex(int $lastWrittenRowIndex): void
     {
         $this->lastWrittenRowIndex = $lastWrittenRowIndex;
+    }
+
+    public function addImage(int $row, int $col, ImageCell $cell): void
+    {
+        $this->images[] = ['row' => $row, 'col' => $col, 'cell' => $cell];
+    }
+
+    /** @return array<array{row: int, col: int, cell: ImageCell}> */
+    public function getImages(): array
+    {
+        return $this->images;
     }
 
     /**

--- a/src/Writer/Common/Entity/Worksheet.php
+++ b/src/Writer/Common/Entity/Worksheet.php
@@ -91,7 +91,9 @@ final class Worksheet
         $this->images[] = ['row' => $row, 'col' => $col, 'cell' => $cell];
     }
 
-    /** @return array<array{row: int, col: int, cell: ImageCell}> */
+    /**
+     * @return array<array{row: int, col: int, cell: ImageCell}>
+     */
     public function getImages(): array
     {
         return $this->images;

--- a/src/Writer/Common/Entity/Worksheet.php
+++ b/src/Writer/Common/Entity/Worksheet.php
@@ -26,7 +26,7 @@ final class Worksheet
     /** @var int Index of the last written row */
     private int $lastWrittenRowIndex = 0;
 
-    /** @var array<array{row: int, col: int, cell: ImageCell}> */
+    /** @var list<array{row: int, col: int, cell: ImageCell}> */
     private array $images = [];
 
     /**
@@ -92,7 +92,7 @@ final class Worksheet
     }
 
     /**
-     * @return array<array{row: int, col: int, cell: ImageCell}>
+     * @return list<array{row: int, col: int, cell: ImageCell}>
      */
     public function getImages(): array
     {

--- a/src/Writer/ODS/Manager/WorksheetManager.php
+++ b/src/Writer/ODS/Manager/WorksheetManager.php
@@ -10,6 +10,7 @@ use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Common\Entity\Row;
 use OpenSpout\Common\Exception\InvalidArgumentException;
 use OpenSpout\Common\Exception\IOException;
+use OpenSpout\Common\Exception\UnsupportedTypeException;
 use OpenSpout\Common\Helper\Escaper\ODS as ODSEscaper;
 use OpenSpout\Writer\Common\Entity\Worksheet;
 use OpenSpout\Writer\Common\Helper\CellHelper;
@@ -194,6 +195,8 @@ final readonly class WorksheetManager implements WorksheetManagerInterface
             $data .= '</table:table-cell>';
         } elseif ($cell instanceof Cell\EmptyCell) {
             $data .= '/>';
+        } elseif ($cell instanceof Cell\ImageCell) {
+            throw new UnsupportedTypeException('ImageCell is not supported in ODS format.');
         }
 
         return $data;

--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -321,16 +321,11 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
                 ++$hyperlinkId;
             }
 
+            if ([] !== $worksheet->getImages()) {
+                $worksheetRelsContent .= '  <Relationship Id="rIdDrawing1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing'.$worksheetId.'.xml"/>'.PHP_EOL;
+            }
+
             $worksheetRelsContent .= '</Relationships>';
-            $drawingRel = [] !== $worksheet->getImages()
-                ? '<Relationship Id="rIdDrawing1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing'.$worksheetId.'.xml"/>'
-                : '';
-            $worksheetRelsContent = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-              <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-                <Relationship Id="rId_comments_vml1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/vmlDrawing" Target="../drawings/vmlDrawing'.$worksheetId.'.vml"/>
-                <Relationship Id="rId_comments1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments" Target="../comments'.$worksheetId.'.xml"/>'
-                .$drawingRel
-                .'</Relationships>';
 
             $folder = $this->getXlWorksheetsFolder().\DIRECTORY_SEPARATOR.'_rels';
             $filename = 'sheet'.$worksheetId.'.xml.rels';

--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -467,13 +467,13 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
 
             $this->getXMLFragmentForHeaderFooter($worksheetFilePointer, $options);
 
-            // Add the legacy drawing for comments
-            fwrite($worksheetFilePointer, '<legacyDrawing r:id="rId_comments_vml1"/>');
-
             if ([] !== $worksheet->getImages()) {
                 fwrite($worksheetFilePointer, '<drawing r:id="rIdDrawing1"/>');
                 $this->createDrawingFiles($worksheet);
             }
+
+            // Add the legacy drawing for comments
+            fwrite($worksheetFilePointer, '<legacyDrawing r:id="rId_comments_vml1"/>');
 
             fwrite($worksheetFilePointer, '</worksheet>');
             fclose($worksheetFilePointer);

--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -862,6 +862,8 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
 
     /**
      * Creates the drawing XML, drawing rels, and media files for a worksheet that contains images.
+     *
+     * @throws IOException
      */
     private function createDrawingFiles(Worksheet $worksheet): void
     {
@@ -894,7 +896,9 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
             $mediaName = 'image'.$sheetId.'_'.$imageIndex.'.'.$ext;
             $mediaTarget = $mediaFolder.\DIRECTORY_SEPARATOR.$mediaName;
 
-            copy($cell->getValue(), $mediaTarget);
+            if (!copy($cell->getValue(), $mediaTarget)) {
+                throw new IOException('Unable to copy image from "'.$cell->getValue().'" to "'.$mediaTarget.'".');
+            }
 
             $picId = $imageIndex + 1;
             $pic = '<xdr:pic>'

--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -861,6 +861,30 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
     }
 
     /**
+     * Builds the <xdr:pic> XML fragment for a single image.
+     * For twoCellAnchor the cx/cy in spPr are irrelevant (sizing comes from the cell grid),
+     * so they default to 0. For oneCellAnchor they should mirror the <xdr:ext> values so
+     * that applications relying on spPr (e.g. LibreOffice) render the image at the correct size.
+     */
+    private function buildPicXml(int $imageIndex, int $picId, int $widthEmu = 0, int $heightEmu = 0): string
+    {
+        return '<xdr:pic>'
+            .'<xdr:nvPicPr>'
+            .'<xdr:cNvPr id="'.$picId.'" name="Image'.$imageIndex.'"/>'
+            .'<xdr:cNvPicPr><a:picLocks noChangeAspect="1"/></xdr:cNvPicPr>'
+            .'</xdr:nvPicPr>'
+            .'<xdr:blipFill>'
+            .'<a:blip r:embed="rId'.$imageIndex.'"/>'
+            .'<a:stretch><a:fillRect/></a:stretch>'
+            .'</xdr:blipFill>'
+            .'<xdr:spPr>'
+            .'<a:xfrm><a:off x="0" y="0"/><a:ext cx="'.$widthEmu.'" cy="'.$heightEmu.'"/></a:xfrm>'
+            .'<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>'
+            .'</xdr:spPr>'
+            .'</xdr:pic>';
+    }
+
+    /**
      * Creates the drawing XML, drawing rels, and media files for a worksheet that contains images.
      *
      * @throws IOException
@@ -901,20 +925,6 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
             }
 
             $picId = $imageIndex + 1;
-            $pic = '<xdr:pic>'
-                .'<xdr:nvPicPr>'
-                .'<xdr:cNvPr id="'.$picId.'" name="Image'.$imageIndex.'"/>'
-                .'<xdr:cNvPicPr><a:picLocks noChangeAspect="1"/></xdr:cNvPicPr>'
-                .'</xdr:nvPicPr>'
-                .'<xdr:blipFill>'
-                .'<a:blip r:embed="rId'.$imageIndex.'"/>'
-                .'<a:stretch><a:fillRect/></a:stretch>'
-                .'</xdr:blipFill>'
-                .'<xdr:spPr>'
-                .'<a:xfrm><a:off x="0" y="0"/><a:ext cx="1" cy="1"/></a:xfrm>'
-                .'<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>'
-                .'</xdr:spPr>'
-                .'</xdr:pic>';
 
             if ($cell->fitToCell) {
                 $drawingXml .= '<xdr:twoCellAnchor editAs="twoCell">'
@@ -926,7 +936,7 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
                     .'<xdr:col>'.($col + 1).'</xdr:col><xdr:colOff>0</xdr:colOff>'
                     .'<xdr:row>'.($row + 1).'</xdr:row><xdr:rowOff>0</xdr:rowOff>'
                     .'</xdr:to>'
-                    .$pic
+                    .$this->buildPicXml($imageIndex, $picId)
                     .'<xdr:clientData/>'
                     .'</xdr:twoCellAnchor>';
             } else {
@@ -938,7 +948,7 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
                     .'<xdr:row>'.$row.'</xdr:row><xdr:rowOff>0</xdr:rowOff>'
                     .'</xdr:from>'
                     .'<xdr:ext cx="'.$widthEmu.'" cy="'.$heightEmu.'"/>'
-                    .$pic
+                    .$this->buildPicXml($imageIndex, $picId, $widthEmu, $heightEmu)
                     .'<xdr:clientData/>'
                     .'</xdr:oneCellAnchor>';
             }

--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -896,17 +896,8 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
 
             copy($cell->getValue(), $mediaTarget);
 
-            $widthEmu = $cell->width * 9525;
-            $heightEmu = $cell->height * 9525;
             $picId = $imageIndex + 1;
-
-            $drawingXml .= '<xdr:oneCellAnchor>'
-                .'<xdr:from>'
-                .'<xdr:col>'.$col.'</xdr:col><xdr:colOff>0</xdr:colOff>'
-                .'<xdr:row>'.$row.'</xdr:row><xdr:rowOff>0</xdr:rowOff>'
-                .'</xdr:from>'
-                .'<xdr:ext cx="'.$widthEmu.'" cy="'.$heightEmu.'"/>'
-                .'<xdr:pic>'
+            $pic = '<xdr:pic>'
                 .'<xdr:nvPicPr>'
                 .'<xdr:cNvPr id="'.$picId.'" name="Image'.$imageIndex.'"/>'
                 .'<xdr:cNvPicPr><a:picLocks noChangeAspect="1"/></xdr:cNvPicPr>'
@@ -916,12 +907,37 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
                 .'<a:stretch><a:fillRect/></a:stretch>'
                 .'</xdr:blipFill>'
                 .'<xdr:spPr>'
-                .'<a:xfrm><a:off x="0" y="0"/><a:ext cx="'.$widthEmu.'" cy="'.$heightEmu.'"/></a:xfrm>'
+                .'<a:xfrm><a:off x="0" y="0"/><a:ext cx="1" cy="1"/></a:xfrm>'
                 .'<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>'
                 .'</xdr:spPr>'
-                .'</xdr:pic>'
-                .'<xdr:clientData/>'
-                .'</xdr:oneCellAnchor>';
+                .'</xdr:pic>';
+
+            if ($cell->fitToCell) {
+                $drawingXml .= '<xdr:twoCellAnchor editAs="twoCell">'
+                    .'<xdr:from>'
+                    .'<xdr:col>'.$col.'</xdr:col><xdr:colOff>0</xdr:colOff>'
+                    .'<xdr:row>'.$row.'</xdr:row><xdr:rowOff>0</xdr:rowOff>'
+                    .'</xdr:from>'
+                    .'<xdr:to>'
+                    .'<xdr:col>'.($col + 1).'</xdr:col><xdr:colOff>0</xdr:colOff>'
+                    .'<xdr:row>'.($row + 1).'</xdr:row><xdr:rowOff>0</xdr:rowOff>'
+                    .'</xdr:to>'
+                    .$pic
+                    .'<xdr:clientData/>'
+                    .'</xdr:twoCellAnchor>';
+            } else {
+                $widthEmu = $cell->width * 9525;
+                $heightEmu = $cell->height * 9525;
+                $drawingXml .= '<xdr:oneCellAnchor>'
+                    .'<xdr:from>'
+                    .'<xdr:col>'.$col.'</xdr:col><xdr:colOff>0</xdr:colOff>'
+                    .'<xdr:row>'.$row.'</xdr:row><xdr:rowOff>0</xdr:rowOff>'
+                    .'</xdr:from>'
+                    .'<xdr:ext cx="'.$widthEmu.'" cy="'.$heightEmu.'"/>'
+                    .$pic
+                    .'<xdr:clientData/>'
+                    .'</xdr:oneCellAnchor>';
+            }
 
             $drawingRelsXml .= '<Relationship Id="rId'.$imageIndex.'"'
                 .' Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"'

--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -166,6 +166,7 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
             EOD;
 
         $imageExtensions = [];
+
         /** @var Worksheet $worksheet */
         foreach ($worksheets as $worksheet) {
             $contentTypesXmlFileContents .= '<Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet'.$worksheet->getId().'.xml"/>';

--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -26,6 +26,7 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
 {
     public const string RELS_FOLDER_NAME = '_rels';
     public const string DRAWINGS_FOLDER_NAME = 'drawings';
+    public const string MEDIA_FOLDER_NAME = 'media';
     public const string DOC_PROPS_FOLDER_NAME = 'docProps';
     public const string XL_FOLDER_NAME = 'xl';
     public const string WORKSHEETS_FOLDER_NAME = 'worksheets';
@@ -164,10 +165,20 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
                 <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
             EOD;
 
+        $imageExtensions = [];
         /** @var Worksheet $worksheet */
         foreach ($worksheets as $worksheet) {
             $contentTypesXmlFileContents .= '<Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet'.$worksheet->getId().'.xml"/>';
             $contentTypesXmlFileContents .= '<Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.comments+xml" PartName="/xl/comments'.$worksheet->getId().'.xml" />';
+            if ([] !== $worksheet->getImages()) {
+                $contentTypesXmlFileContents .= '<Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing'.$worksheet->getId().'.xml"/>';
+                foreach ($worksheet->getImages() as $image) {
+                    $imageExtensions[$image['cell']->getExtension()] = $image['cell']->mimeType;
+                }
+            }
+        }
+        foreach ($imageExtensions as $ext => $mime) {
+            $contentTypesXmlFileContents .= '<Default ContentType="'.$mime.'" Extension="'.$ext.'"/>';
         }
 
         $contentTypesXmlFileContents .= <<<'EOD'
@@ -296,11 +307,15 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
 
         foreach ($worksheets as $worksheet) {
             $worksheetId = $worksheet->getId();
+            $drawingRel = [] !== $worksheet->getImages()
+                ? '<Relationship Id="rIdDrawing1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing'.$worksheetId.'.xml"/>'
+                : '';
             $worksheetRelsContent = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
               <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
                 <Relationship Id="rId_comments_vml1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/vmlDrawing" Target="../drawings/vmlDrawing'.$worksheetId.'.vml"/>
-                <Relationship Id="rId_comments1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments" Target="../comments'.$worksheetId.'.xml"/>
-              </Relationships>';
+                <Relationship Id="rId_comments1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments" Target="../comments'.$worksheetId.'.xml"/>'
+                .$drawingRel
+                .'</Relationships>';
 
             $folder = $this->getXlWorksheetsFolder().\DIRECTORY_SEPARATOR.'_rels';
             $filename = 'sheet'.$worksheetId.'.xml.rels';
@@ -454,6 +469,11 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
 
             // Add the legacy drawing for comments
             fwrite($worksheetFilePointer, '<legacyDrawing r:id="rId_comments_vml1"/>');
+
+            if ([] !== $worksheet->getImages()) {
+                fwrite($worksheetFilePointer, '<drawing r:id="rIdDrawing1"/>');
+                $this->createDrawingFiles($worksheet);
+            }
 
             fwrite($worksheetFilePointer, '</worksheet>');
             fclose($worksheetFilePointer);
@@ -838,6 +858,83 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
         $this->xlWorksheetsFolder = $this->createFolder($this->xlFolder, self::WORKSHEETS_FOLDER_NAME);
 
         return $this;
+    }
+
+    /**
+     * Creates the drawing XML, drawing rels, and media files for a worksheet that contains images.
+     */
+    private function createDrawingFiles(Worksheet $worksheet): void
+    {
+        $drawingsFolder = $this->xlFolder.\DIRECTORY_SEPARATOR.self::DRAWINGS_FOLDER_NAME;
+        $drawingsRelsFolder = $drawingsFolder.\DIRECTORY_SEPARATOR.self::RELS_FOLDER_NAME;
+        $mediaFolder = $this->xlFolder.\DIRECTORY_SEPARATOR.self::MEDIA_FOLDER_NAME;
+
+        if (!is_dir($drawingsRelsFolder)) {
+            $this->createFolder($drawingsFolder, self::RELS_FOLDER_NAME);
+        }
+        if (!is_dir($mediaFolder)) {
+            $this->createFolder($this->xlFolder, self::MEDIA_FOLDER_NAME);
+        }
+
+        $sheetId = $worksheet->getId();
+        $drawingXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            .'<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"'
+            .' xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"'
+            .' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">';
+
+        $drawingRelsXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            .'<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">';
+
+        $imageIndex = 1;
+        foreach ($worksheet->getImages() as $image) {
+            $cell = $image['cell'];
+            $row = $image['row'];
+            $col = $image['col'];
+            $ext = $cell->getExtension();
+            $mediaName = 'image'.$sheetId.'_'.$imageIndex.'.'.$ext;
+            $mediaTarget = $mediaFolder.\DIRECTORY_SEPARATOR.$mediaName;
+
+            copy($cell->getValue(), $mediaTarget);
+
+            $widthEmu = $cell->width * 9525;
+            $heightEmu = $cell->height * 9525;
+            $picId = $imageIndex + 1;
+
+            $drawingXml .= '<xdr:oneCellAnchor>'
+                .'<xdr:from>'
+                .'<xdr:col>'.$col.'</xdr:col><xdr:colOff>0</xdr:colOff>'
+                .'<xdr:row>'.$row.'</xdr:row><xdr:rowOff>0</xdr:rowOff>'
+                .'</xdr:from>'
+                .'<xdr:ext cx="'.$widthEmu.'" cy="'.$heightEmu.'"/>'
+                .'<xdr:pic>'
+                .'<xdr:nvPicPr>'
+                .'<xdr:cNvPr id="'.$picId.'" name="Image'.$imageIndex.'"/>'
+                .'<xdr:cNvPicPr><a:picLocks noChangeAspect="1"/></xdr:cNvPicPr>'
+                .'</xdr:nvPicPr>'
+                .'<xdr:blipFill>'
+                .'<a:blip r:embed="rId'.$imageIndex.'"/>'
+                .'<a:stretch><a:fillRect/></a:stretch>'
+                .'</xdr:blipFill>'
+                .'<xdr:spPr>'
+                .'<a:xfrm><a:off x="0" y="0"/><a:ext cx="'.$widthEmu.'" cy="'.$heightEmu.'"/></a:xfrm>'
+                .'<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>'
+                .'</xdr:spPr>'
+                .'</xdr:pic>'
+                .'<xdr:clientData/>'
+                .'</xdr:oneCellAnchor>';
+
+            $drawingRelsXml .= '<Relationship Id="rId'.$imageIndex.'"'
+                .' Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"'
+                .' Target="../media/'.$mediaName.'"/>';
+
+            ++$imageIndex;
+        }
+
+        $drawingXml .= '</xdr:wsDr>';
+        $drawingRelsXml .= '</Relationships>';
+
+        $this->createFileWithContents($drawingsFolder, 'drawing'.$sheetId.'.xml', $drawingXml);
+        $this->createFileWithContents($drawingsRelsFolder, 'drawing'.$sheetId.'.xml.rels', $drawingRelsXml);
     }
 
     /**

--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenSpout\Writer\XLSX\Helper;
 
 use DateTimeImmutable;
+use OpenSpout\Common\Entity\Cell\ImageCell;
 use OpenSpout\Common\Exception\IOException;
 use OpenSpout\Common\Helper\Escaper\XLSX;
 use OpenSpout\Common\Helper\FileSystemHelper as CommonFileSystemHelper;
@@ -14,6 +15,7 @@ use OpenSpout\Writer\Common\Helper\CellHelper;
 use OpenSpout\Writer\Common\Helper\FileSystemWithRootFolderHelperInterface;
 use OpenSpout\Writer\Common\Helper\ZipHelper;
 use OpenSpout\Writer\XLSX\Manager\HyperlinkManager;
+use OpenSpout\Writer\XLSX\Manager\ImageManager;
 use OpenSpout\Writer\XLSX\Manager\Style\StyleManager;
 use OpenSpout\Writer\XLSX\MergeCell;
 use OpenSpout\Writer\XLSX\Options;
@@ -352,7 +354,7 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
      *
      * @param Worksheet[] $worksheets
      */
-    public function createContentFiles(Options $options, array $worksheets, HyperlinkManager $hyperlinkManager): self
+    public function createContentFiles(Options $options, array $worksheets, HyperlinkManager $hyperlinkManager, ImageManager $imageManager): self
     {
         $allMergeCells = $options->getMergeCells();
         $allValidationRules = $options->getValidationRules();
@@ -490,7 +492,7 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
 
             if ([] !== $worksheet->getImages()) {
                 fwrite($worksheetFilePointer, '<drawing r:id="rIdDrawing1"/>');
-                $this->createDrawingFiles($worksheet);
+                $this->createDrawingFiles($worksheet, $imageManager);
             }
 
             // Add the legacy drawing for comments
@@ -910,7 +912,7 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
      *
      * @throws IOException
      */
-    private function createDrawingFiles(Worksheet $worksheet): void
+    private function createDrawingFiles(Worksheet $worksheet, ImageManager $imageManager): void
     {
         $drawingsFolder = $this->xlFolder.\DIRECTORY_SEPARATOR.self::DRAWINGS_FOLDER_NAME;
         $drawingsRelsFolder = $drawingsFolder.\DIRECTORY_SEPARATOR.self::RELS_FOLDER_NAME;
@@ -924,28 +926,57 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
         }
 
         $sheetId = $worksheet->getId();
+
+        // Build a map of path → local rel ID (deduplicated within this drawing).
+        // Multiple cells in the same sheet that reference the same file share one
+        // relationship entry, pointing to a single media file in the archive.
+        /** @var array<string, array{relId: int, cell: ImageCell}> $pathToLocalRel */
+        $pathToLocalRel = [];
+        $localRelIdCounter = 1;
+        foreach ($worksheet->getImages() as $image) {
+            $path = $image['cell']->getValue();
+            if (!isset($pathToLocalRel[$path])) {
+                $pathToLocalRel[$path] = ['relId' => $localRelIdCounter++, 'cell' => $image['cell']];
+            }
+        }
+
+        // Copy each unique image into the media folder (only if not already copied
+        // by a previous worksheet) and build the drawing rels XML.
+        $drawingRelsXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            .'<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">';
+
+        foreach ($pathToLocalRel as $path => ['relId' => $localRelId, 'cell' => $cell]) {
+            $isNew = !$imageManager->has($path);
+            $globalId = $imageManager->register($path);
+            $mediaName = 'image'.$globalId.'.'.$cell->getExtension();
+
+            if ($isNew) {
+                $mediaTarget = $mediaFolder.\DIRECTORY_SEPARATOR.$mediaName;
+                if (!copy($path, $mediaTarget)) {
+                    throw new IOException('Unable to copy image from "'.$path.'" to "'.$mediaTarget.'".');
+                }
+            }
+
+            $drawingRelsXml .= '<Relationship Id="rId'.$localRelId.'"'
+                .' Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"'
+                .' Target="../media/'.$mediaName.'"/>';
+        }
+
+        $drawingRelsXml .= '</Relationships>';
+
+        // Build the drawing XML — one anchor per cell, referencing the local rel ID.
         $drawingXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
             .'<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"'
             .' xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"'
             .' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">';
 
-        $drawingRelsXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
-            .'<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">';
-
-        $imageIndex = 1;
+        $picCounter = 1;
         foreach ($worksheet->getImages() as $image) {
             $cell = $image['cell'];
             $row = $image['row'];
             $col = $image['col'];
-            $ext = $cell->getExtension();
-            $mediaName = 'image'.$sheetId.'_'.$imageIndex.'.'.$ext;
-            $mediaTarget = $mediaFolder.\DIRECTORY_SEPARATOR.$mediaName;
-
-            if (!copy($cell->getValue(), $mediaTarget)) {
-                throw new IOException('Unable to copy image from "'.$cell->getValue().'" to "'.$mediaTarget.'".');
-            }
-
-            $picId = $imageIndex + 1;
+            $localRelId = $pathToLocalRel[$cell->getValue()]['relId'];
+            $picId = $picCounter + 1;
 
             if ($cell->fitToCell) {
                 $drawingXml .= '<xdr:twoCellAnchor editAs="twoCell">'
@@ -957,7 +988,7 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
                     .'<xdr:col>'.($col + 1).'</xdr:col><xdr:colOff>0</xdr:colOff>'
                     .'<xdr:row>'.($row + 1).'</xdr:row><xdr:rowOff>0</xdr:rowOff>'
                     .'</xdr:to>'
-                    .$this->buildPicXml($imageIndex, $picId)
+                    .$this->buildPicXml($localRelId, $picId)
                     .'<xdr:clientData/>'
                     .'</xdr:twoCellAnchor>';
             } else {
@@ -969,20 +1000,15 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
                     .'<xdr:row>'.$row.'</xdr:row><xdr:rowOff>0</xdr:rowOff>'
                     .'</xdr:from>'
                     .'<xdr:ext cx="'.$widthEmu.'" cy="'.$heightEmu.'"/>'
-                    .$this->buildPicXml($imageIndex, $picId, $widthEmu, $heightEmu)
+                    .$this->buildPicXml($localRelId, $picId, $widthEmu, $heightEmu)
                     .'<xdr:clientData/>'
                     .'</xdr:oneCellAnchor>';
             }
 
-            $drawingRelsXml .= '<Relationship Id="rId'.$imageIndex.'"'
-                .' Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"'
-                .' Target="../media/'.$mediaName.'"/>';
-
-            ++$imageIndex;
+            ++$picCounter;
         }
 
         $drawingXml .= '</xdr:wsDr>';
-        $drawingRelsXml .= '</Relationships>';
 
         $this->createFileWithContents($drawingsFolder, 'drawing'.$sheetId.'.xml', $drawingXml);
         $this->createFileWithContents($drawingsRelsFolder, 'drawing'.$sheetId.'.xml.rels', $drawingRelsXml);

--- a/src/Writer/XLSX/Manager/ImageManager.php
+++ b/src/Writer/XLSX/Manager/ImageManager.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSpout\Writer\XLSX\Manager;
+
+/**
+ * Tracks image paths across the whole workbook so that identical source files
+ * are embedded in the XLSX archive exactly once, regardless of how many cells
+ * reference them.
+ *
+ * @internal
+ */
+final class ImageManager
+{
+    /** @var array<string, int> Maps absolute path to its global media ID */
+    private array $pathToId = [];
+
+    private int $nextId = 1;
+
+    /**
+     * Returns true if this path has already been registered.
+     * Call this *before* register() to decide whether the media file needs to
+     * be copied.
+     */
+    public function has(string $path): bool
+    {
+        return isset($this->pathToId[$path]);
+    }
+
+    /**
+     * Returns the global media ID for the given path, registering it with a
+     * new ID if it has not been seen before.
+     */
+    public function register(string $path): int
+    {
+        if (!isset($this->pathToId[$path])) {
+            $this->pathToId[$path] = $this->nextId++;
+        }
+
+        return $this->pathToId[$path];
+    }
+}

--- a/src/Writer/XLSX/Manager/WorkbookManager.php
+++ b/src/Writer/XLSX/Manager/WorkbookManager.php
@@ -33,7 +33,8 @@ final class WorkbookManager extends AbstractWorkbookManager
         WorksheetManager $worksheetManager,
         StyleManager $styleManager,
         FileSystemHelper $fileSystemHelper,
-        private readonly HyperlinkManager $hyperlinkManager
+        private readonly HyperlinkManager $hyperlinkManager,
+        private readonly ImageManager $imageManager,
     ) {
         parent::__construct(
             $workbook,
@@ -70,7 +71,7 @@ final class WorkbookManager extends AbstractWorkbookManager
         $worksheets = $this->getWorksheets();
 
         $this->fileSystemHelper
-            ->createContentFiles($this->options, $worksheets, $this->hyperlinkManager)
+            ->createContentFiles($this->options, $worksheets, $this->hyperlinkManager, $this->imageManager)
             ->deleteWorksheetTempFolder()
             ->createContentTypesFile($worksheets)
             ->createWorkbookFile($this->options, $worksheets)

--- a/src/Writer/XLSX/Manager/WorksheetManager.php
+++ b/src/Writer/XLSX/Manager/WorksheetManager.php
@@ -151,7 +151,7 @@ final readonly class WorksheetManager implements WorksheetManagerInterface
                 $cellXML = '';
             }
         } elseif ($cell instanceof Cell\ImageCell) {
-            // Image is embedded as a drawing; emit an empty cell placeholder
+            // Image is embedded as a drawing; no <c> tag is written here.
             $cellXML = '';
         }
 

--- a/src/Writer/XLSX/Manager/WorksheetManager.php
+++ b/src/Writer/XLSX/Manager/WorksheetManager.php
@@ -91,6 +91,9 @@ final readonly class WorksheetManager implements WorksheetManagerInterface
         $rowXML = "<row r=\"{$rowIndexOneBased}\" spans=\"1:{$numCells}\" ".($rowHeight > 0 ? "ht=\"{$rowHeight}\" " : '')."customHeight=\"{$hasCustomHeight}\">";
 
         foreach ($row->cells as $columnIndexZeroBased => $cell) {
+            if ($cell instanceof Cell\ImageCell) {
+                $worksheet->addImage($rowIndexOneBased - 1, $columnIndexZeroBased, $cell);
+            }
             $styleId = 0;
             if (null !== $cell->style) {
                 $styleId = $this->styleManager->registerStyle($cell->style);
@@ -147,6 +150,9 @@ final readonly class WorksheetManager implements WorksheetManagerInterface
                 // NOTE: not appending to $cellXML is the right behavior!!
                 $cellXML = '';
             }
+        } elseif ($cell instanceof Cell\ImageCell) {
+            // Image is embedded as a drawing; emit an empty cell placeholder
+            $cellXML = '';
         }
 
         return $cellXML;

--- a/src/Writer/XLSX/Writer.php
+++ b/src/Writer/XLSX/Writer.php
@@ -12,6 +12,7 @@ use OpenSpout\Writer\Common\Helper\ZipHelper;
 use OpenSpout\Writer\XLSX\Helper\FileSystemHelper;
 use OpenSpout\Writer\XLSX\Manager\CommentsManager;
 use OpenSpout\Writer\XLSX\Manager\HyperlinkManager;
+use OpenSpout\Writer\XLSX\Manager\ImageManager;
 use OpenSpout\Writer\XLSX\Manager\SharedStringsManager;
 use OpenSpout\Writer\XLSX\Manager\Style\StyleManager;
 use OpenSpout\Writer\XLSX\Manager\Style\StyleRegistry;
@@ -65,6 +66,7 @@ final class Writer extends AbstractWriterMultiSheets
 
         $commentsManager = new CommentsManager($xlFolder, new XLSX());
         $hyperlinkManager = new HyperlinkManager();
+        $imageManager = new ImageManager();
 
         $worksheetManager = new WorksheetManager(
             $this->options,
@@ -82,7 +84,8 @@ final class Writer extends AbstractWriterMultiSheets
             $worksheetManager,
             $styleManager,
             $fileSystemHelper,
-            $hyperlinkManager
+            $hyperlinkManager,
+            $imageManager,
         );
     }
 }

--- a/tests/Writer/CSV/WriterTest.php
+++ b/tests/Writer/CSV/WriterTest.php
@@ -279,7 +279,7 @@ final class WriterTest extends TestCase
     {
         // Minimal 1×1 image
         $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image_csv.png';
-        file_put_contents($imagePath, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg=='));
+        file_put_contents($imagePath, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg==', true));
 
         try {
             $fileName = 'test_image_cell_throws.csv';

--- a/tests/Writer/CSV/WriterTest.php
+++ b/tests/Writer/CSV/WriterTest.php
@@ -12,6 +12,7 @@ use OpenSpout\Common\Exception\IOException;
 use OpenSpout\Common\Exception\UnsupportedTypeException;
 use OpenSpout\Common\Helper\EncodingHelper;
 use OpenSpout\TestUsingResource;
+use OpenSpout\Writer\Common\Helper\ImageHelperTrait;
 use OpenSpout\Writer\Exception\WriterNotOpenedException;
 use PHPUnit\Framework\TestCase;
 
@@ -20,6 +21,8 @@ use PHPUnit\Framework\TestCase;
  */
 final class WriterTest extends TestCase
 {
+    use ImageHelperTrait;
+
     public function testWriteShouldThrowExceptionIfCannotOpenFileForWriting(): void
     {
         $fileName = 'file_that_wont_be_written.csv';
@@ -277,21 +280,13 @@ final class WriterTest extends TestCase
 
     public function testWriteImageCellShouldThrowException(): void
     {
-        // Minimal 1×1 image
-        $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image_csv.png';
-        file_put_contents($imagePath, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg==', true));
+        $fileName = 'test_image_cell_throws.csv';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+        $writer = new Writer();
+        $writer->openToFile($resourcePath);
 
-        try {
-            $fileName = 'test_image_cell_throws.csv';
-            $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
-            $writer = new Writer();
-            $writer->openToFile($resourcePath);
-
-            $this->expectException(UnsupportedTypeException::class);
-            $writer->addRow(new Row([new ImageCell($imagePath, 1, 1)]));
-        } finally {
-            unlink($imagePath);
-        }
+        $this->expectException(UnsupportedTypeException::class);
+        $writer->addRow(new Row([new ImageCell($this->testImagePath, 1, 1)]));
     }
 
     /**

--- a/tests/Writer/CSV/WriterTest.php
+++ b/tests/Writer/CSV/WriterTest.php
@@ -6,6 +6,7 @@ namespace OpenSpout\Writer\CSV;
 
 use DateInterval;
 use DateTime;
+use Imagick;
 use OpenSpout\Common\Entity\Cell\ImageCell;
 use OpenSpout\Common\Entity\Row;
 use OpenSpout\Common\Exception\IOException;
@@ -282,13 +283,15 @@ final class WriterTest extends TestCase
         }
 
         $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image_csv.png';
+
         try {
             if (\extension_loaded('gd')) {
                 $img = imagecreatetruecolor(1, 1);
                 imagepng($img, $imagePath);
                 imagedestroy($img);
             } else {
-                $img = new \Imagick();
+                // phpcs:ignore
+                $img = new Imagick();
                 $img->newImage(1, 1, 'white');
                 $img->setImageFormat('png');
                 $img->writeImage($imagePath);

--- a/tests/Writer/CSV/WriterTest.php
+++ b/tests/Writer/CSV/WriterTest.php
@@ -6,8 +6,10 @@ namespace OpenSpout\Writer\CSV;
 
 use DateInterval;
 use DateTime;
+use OpenSpout\Common\Entity\Cell\ImageCell;
 use OpenSpout\Common\Entity\Row;
 use OpenSpout\Common\Exception\IOException;
+use OpenSpout\Common\Exception\UnsupportedTypeException;
 use OpenSpout\Common\Helper\EncodingHelper;
 use OpenSpout\TestUsingResource;
 use OpenSpout\Writer\Exception\WriterNotOpenedException;
@@ -271,6 +273,31 @@ final class WriterTest extends TestCase
         self::assertSame(5, $writer->getWrittenRowCount());
         $writer->close();
         self::assertSame(5, $writer->getWrittenRowCount());
+    }
+
+    public function testWriteImageCellShouldThrowException(): void
+    {
+        if (!\extension_loaded('gd') && !\extension_loaded('imagick')) {
+            self::markTestSkipped('Neither gd nor imagick extension is available.');
+        }
+
+        $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image_csv.png';
+        $img = imagecreatetruecolor(1, 1);
+        \assert(false !== $img);
+        imagepng($img, $imagePath);
+        imagedestroy($img);
+
+        $fileName = 'test_image_cell_throws.csv';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+        $writer = new Writer();
+        $writer->openToFile($resourcePath);
+
+        $this->expectException(UnsupportedTypeException::class);
+        try {
+            $writer->addRow(new Row([new ImageCell($imagePath)]));
+        } finally {
+            unlink($imagePath);
+        }
     }
 
     /**

--- a/tests/Writer/CSV/WriterTest.php
+++ b/tests/Writer/CSV/WriterTest.php
@@ -6,7 +6,6 @@ namespace OpenSpout\Writer\CSV;
 
 use DateInterval;
 use DateTime;
-use Imagick;
 use OpenSpout\Common\Entity\Cell\ImageCell;
 use OpenSpout\Common\Entity\Row;
 use OpenSpout\Common\Exception\IOException;
@@ -278,33 +277,18 @@ final class WriterTest extends TestCase
 
     public function testWriteImageCellShouldThrowException(): void
     {
-        if (!\extension_loaded('gd') && !\extension_loaded('imagick')) {
-            self::markTestSkipped('Neither gd nor imagick extension is available.');
-        }
-
+        // Minimal 1×1 image
         $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image_csv.png';
+        file_put_contents($imagePath, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg=='));
 
         try {
-            if (\extension_loaded('gd')) {
-                $img = imagecreatetruecolor(1, 1);
-                imagepng($img, $imagePath);
-                imagedestroy($img);
-            } else {
-                // phpcs:ignore
-                $img = new Imagick();
-                $img->newImage(1, 1, 'white');
-                $img->setImageFormat('png');
-                $img->writeImage($imagePath);
-                $img->clear();
-            }
-
             $fileName = 'test_image_cell_throws.csv';
             $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
             $writer = new Writer();
             $writer->openToFile($resourcePath);
 
             $this->expectException(UnsupportedTypeException::class);
-            $writer->addRow(new Row([new ImageCell($imagePath)]));
+            $writer->addRow(new Row([new ImageCell($imagePath, 1, 1)]));
         } finally {
             unlink($imagePath);
         }

--- a/tests/Writer/CSV/WriterTest.php
+++ b/tests/Writer/CSV/WriterTest.php
@@ -282,25 +282,25 @@ final class WriterTest extends TestCase
         }
 
         $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image_csv.png';
-        if (\extension_loaded('gd')) {
-            $img = imagecreatetruecolor(1, 1);
-            imagepng($img, $imagePath);
-            imagedestroy($img);
-        } else {
-            $img = new \Imagick();
-            $img->newImage(1, 1, 'white');
-            $img->setImageFormat('png');
-            $img->writeImage($imagePath);
-            $img->clear();
-        }
-
-        $fileName = 'test_image_cell_throws.csv';
-        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
-        $writer = new Writer();
-        $writer->openToFile($resourcePath);
-
-        $this->expectException(UnsupportedTypeException::class);
         try {
+            if (\extension_loaded('gd')) {
+                $img = imagecreatetruecolor(1, 1);
+                imagepng($img, $imagePath);
+                imagedestroy($img);
+            } else {
+                $img = new \Imagick();
+                $img->newImage(1, 1, 'white');
+                $img->setImageFormat('png');
+                $img->writeImage($imagePath);
+                $img->clear();
+            }
+
+            $fileName = 'test_image_cell_throws.csv';
+            $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+            $writer = new Writer();
+            $writer->openToFile($resourcePath);
+
+            $this->expectException(UnsupportedTypeException::class);
             $writer->addRow(new Row([new ImageCell($imagePath)]));
         } finally {
             unlink($imagePath);

--- a/tests/Writer/CSV/WriterTest.php
+++ b/tests/Writer/CSV/WriterTest.php
@@ -282,10 +282,17 @@ final class WriterTest extends TestCase
         }
 
         $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image_csv.png';
-        $img = imagecreatetruecolor(1, 1);
-        \assert(false !== $img);
-        imagepng($img, $imagePath);
-        imagedestroy($img);
+        if (\extension_loaded('gd')) {
+            $img = imagecreatetruecolor(1, 1);
+            imagepng($img, $imagePath);
+            imagedestroy($img);
+        } else {
+            $img = new \Imagick();
+            $img->newImage(1, 1, 'white');
+            $img->setImageFormat('png');
+            $img->writeImage($imagePath);
+            $img->clear();
+        }
 
         $fileName = 'test_image_cell_throws.csv';
         $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);

--- a/tests/Writer/Common/Helper/ImageHelperTrait.php
+++ b/tests/Writer/Common/Helper/ImageHelperTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace OpenSpout\Writer\Common\Helper;
+
+trait ImageHelperTrait
+{
+    protected string $testImagePath;
+
+    protected function setUp(): void
+    {
+        // Minimal 1×1 white PNG
+        $this->testImagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image.png';
+        file_put_contents($this->testImagePath, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg==', true));
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->testImagePath)) {
+            unlink($this->testImagePath);
+        }
+    }
+}

--- a/tests/Writer/ODS/WriterTest.php
+++ b/tests/Writer/ODS/WriterTest.php
@@ -20,6 +20,7 @@ use OpenSpout\Reader\Wrapper\XMLReader;
 use OpenSpout\TestUsingResource;
 use OpenSpout\Writer\AutoFilter;
 use OpenSpout\Writer\Common\Entity\Sheet;
+use OpenSpout\Writer\Common\Helper\ImageHelperTrait;
 use OpenSpout\Writer\Common\Manager\SheetManager;
 use OpenSpout\Writer\Exception\SheetNotFoundException;
 use OpenSpout\Writer\Exception\WriterNotOpenedException;
@@ -33,6 +34,8 @@ use ReflectionHelper;
  */
 final class WriterTest extends TestCase
 {
+    use ImageHelperTrait;
+
     public function testAddRowShouldThrowExceptionIfCannotOpenAFileForWriting(): void
     {
         $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
@@ -491,22 +494,14 @@ final class WriterTest extends TestCase
 
     public function testWriteImageCellShouldThrowException(): void
     {
-        // Minimal 1×1 image
-        $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image_ods.png';
-        file_put_contents($imagePath, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg==', true));
+        $fileName = 'test_image_cell_throws.ods';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+        $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
 
-        try {
-            $fileName = 'test_image_cell_throws.ods';
-            $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
-            $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
-            $writer = new Writer($options);
-            $writer->openToFile($resourcePath);
-
-            $this->expectException(UnsupportedTypeException::class);
-            $writer->addRow(new Row([new ImageCell($imagePath, 1, 1)]));
-        } finally {
-            unlink($imagePath);
-        }
+        $this->expectException(UnsupportedTypeException::class);
+        $writer->addRow(new Row([new ImageCell($this->testImagePath, 1, 1)]));
     }
 
     /**

--- a/tests/Writer/ODS/WriterTest.php
+++ b/tests/Writer/ODS/WriterTest.php
@@ -10,6 +10,7 @@ use DateTimeZone;
 use DOMElement;
 use DOMNode;
 use finfo;
+use Imagick;
 use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Common\Entity\Cell\ImageCell;
 use OpenSpout\Common\Entity\Row;
@@ -489,6 +490,41 @@ final class WriterTest extends TestCase
         self::assertSame("'Sheet2'.A1:'Sheet2'.AA11", $targetRangeAddress);
     }
 
+    public function testWriteImageCellShouldThrowException(): void
+    {
+        if (!\extension_loaded('gd') && !\extension_loaded('imagick')) {
+            self::markTestSkipped('Neither gd nor imagick extension is available.');
+        }
+
+        $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image_ods.png';
+
+        try {
+            if (\extension_loaded('gd')) {
+                $img = imagecreatetruecolor(1, 1);
+                imagepng($img, $imagePath);
+                imagedestroy($img);
+            } else {
+                // phpcs:ignore
+                $img = new Imagick();
+                $img->newImage(1, 1, 'white');
+                $img->setImageFormat('png');
+                $img->writeImage($imagePath);
+                $img->clear();
+            }
+
+            $fileName = 'test_image_cell_throws.ods';
+            $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+            $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
+            $writer = new Writer($options);
+            $writer->openToFile($resourcePath);
+
+            $this->expectException(UnsupportedTypeException::class);
+            $writer->addRow(new Row([new ImageCell($imagePath)]));
+        } finally {
+            unlink($imagePath);
+        }
+    }
+
     /**
      * @param Row[] $allRows
      */
@@ -593,39 +629,6 @@ final class WriterTest extends TestCase
         $xmlReader = $this->moveReaderToCorrectTableNode($fileName, $sheetIndex);
 
         return $xmlReader->readOuterXml();
-    }
-
-    public function testWriteImageCellShouldThrowException(): void
-    {
-        if (!\extension_loaded('gd') && !\extension_loaded('imagick')) {
-            self::markTestSkipped('Neither gd nor imagick extension is available.');
-        }
-
-        $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image_ods.png';
-        try {
-            if (\extension_loaded('gd')) {
-                $img = imagecreatetruecolor(1, 1);
-                imagepng($img, $imagePath);
-                imagedestroy($img);
-            } else {
-                $img = new \Imagick();
-                $img->newImage(1, 1, 'white');
-                $img->setImageFormat('png');
-                $img->writeImage($imagePath);
-                $img->clear();
-            }
-
-            $fileName = 'test_image_cell_throws.ods';
-            $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
-            $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
-            $writer = new Writer($options);
-            $writer->openToFile($resourcePath);
-
-            $this->expectException(UnsupportedTypeException::class);
-            $writer->addRow(new Row([new ImageCell($imagePath)]));
-        } finally {
-            unlink($imagePath);
-        }
     }
 
     private function moveReaderToCorrectTableNode(string $fileName, int $sheetIndex): XMLReader

--- a/tests/Writer/ODS/WriterTest.php
+++ b/tests/Writer/ODS/WriterTest.php
@@ -10,7 +10,6 @@ use DateTimeZone;
 use DOMElement;
 use DOMNode;
 use finfo;
-use Imagick;
 use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Common\Entity\Cell\ImageCell;
 use OpenSpout\Common\Entity\Row;
@@ -492,26 +491,11 @@ final class WriterTest extends TestCase
 
     public function testWriteImageCellShouldThrowException(): void
     {
-        if (!\extension_loaded('gd') && !\extension_loaded('imagick')) {
-            self::markTestSkipped('Neither gd nor imagick extension is available.');
-        }
-
+        // Minimal 1×1 image
         $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image_ods.png';
+        file_put_contents($imagePath, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg=='));
 
         try {
-            if (\extension_loaded('gd')) {
-                $img = imagecreatetruecolor(1, 1);
-                imagepng($img, $imagePath);
-                imagedestroy($img);
-            } else {
-                // phpcs:ignore
-                $img = new Imagick();
-                $img->newImage(1, 1, 'white');
-                $img->setImageFormat('png');
-                $img->writeImage($imagePath);
-                $img->clear();
-            }
-
             $fileName = 'test_image_cell_throws.ods';
             $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
             $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
@@ -519,7 +503,7 @@ final class WriterTest extends TestCase
             $writer->openToFile($resourcePath);
 
             $this->expectException(UnsupportedTypeException::class);
-            $writer->addRow(new Row([new ImageCell($imagePath)]));
+            $writer->addRow(new Row([new ImageCell($imagePath, 1, 1)]));
         } finally {
             unlink($imagePath);
         }

--- a/tests/Writer/ODS/WriterTest.php
+++ b/tests/Writer/ODS/WriterTest.php
@@ -602,26 +602,26 @@ final class WriterTest extends TestCase
         }
 
         $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image_ods.png';
-        if (\extension_loaded('gd')) {
-            $img = imagecreatetruecolor(1, 1);
-            imagepng($img, $imagePath);
-            imagedestroy($img);
-        } else {
-            $img = new \Imagick();
-            $img->newImage(1, 1, 'white');
-            $img->setImageFormat('png');
-            $img->writeImage($imagePath);
-            $img->clear();
-        }
-
-        $fileName = 'test_image_cell_throws.ods';
-        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
-        $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
-        $writer = new Writer($options);
-        $writer->openToFile($resourcePath);
-
-        $this->expectException(UnsupportedTypeException::class);
         try {
+            if (\extension_loaded('gd')) {
+                $img = imagecreatetruecolor(1, 1);
+                imagepng($img, $imagePath);
+                imagedestroy($img);
+            } else {
+                $img = new \Imagick();
+                $img->newImage(1, 1, 'white');
+                $img->setImageFormat('png');
+                $img->writeImage($imagePath);
+                $img->clear();
+            }
+
+            $fileName = 'test_image_cell_throws.ods';
+            $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+            $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
+            $writer = new Writer($options);
+            $writer->openToFile($resourcePath);
+
+            $this->expectException(UnsupportedTypeException::class);
             $writer->addRow(new Row([new ImageCell($imagePath)]));
         } finally {
             unlink($imagePath);

--- a/tests/Writer/ODS/WriterTest.php
+++ b/tests/Writer/ODS/WriterTest.php
@@ -11,8 +11,10 @@ use DOMElement;
 use DOMNode;
 use finfo;
 use OpenSpout\Common\Entity\Cell;
+use OpenSpout\Common\Entity\Cell\ImageCell;
 use OpenSpout\Common\Entity\Row;
 use OpenSpout\Common\Exception\IOException;
+use OpenSpout\Common\Exception\UnsupportedTypeException;
 use OpenSpout\Common\Helper\StringHelper;
 use OpenSpout\Reader\Wrapper\XMLReader;
 use OpenSpout\TestUsingResource;
@@ -591,6 +593,32 @@ final class WriterTest extends TestCase
         $xmlReader = $this->moveReaderToCorrectTableNode($fileName, $sheetIndex);
 
         return $xmlReader->readOuterXml();
+    }
+
+    public function testWriteImageCellShouldThrowException(): void
+    {
+        if (!\extension_loaded('gd') && !\extension_loaded('imagick')) {
+            self::markTestSkipped('Neither gd nor imagick extension is available.');
+        }
+
+        $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image_ods.png';
+        $img = imagecreatetruecolor(1, 1);
+        \assert(false !== $img);
+        imagepng($img, $imagePath);
+        imagedestroy($img);
+
+        $fileName = 'test_image_cell_throws.ods';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+        $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+
+        $this->expectException(UnsupportedTypeException::class);
+        try {
+            $writer->addRow(new Row([new ImageCell($imagePath)]));
+        } finally {
+            unlink($imagePath);
+        }
     }
 
     private function moveReaderToCorrectTableNode(string $fileName, int $sheetIndex): XMLReader

--- a/tests/Writer/ODS/WriterTest.php
+++ b/tests/Writer/ODS/WriterTest.php
@@ -493,7 +493,7 @@ final class WriterTest extends TestCase
     {
         // Minimal 1×1 image
         $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image_ods.png';
-        file_put_contents($imagePath, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg=='));
+        file_put_contents($imagePath, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg==', true));
 
         try {
             $fileName = 'test_image_cell_throws.ods';

--- a/tests/Writer/ODS/WriterTest.php
+++ b/tests/Writer/ODS/WriterTest.php
@@ -602,10 +602,17 @@ final class WriterTest extends TestCase
         }
 
         $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image_ods.png';
-        $img = imagecreatetruecolor(1, 1);
-        \assert(false !== $img);
-        imagepng($img, $imagePath);
-        imagedestroy($img);
+        if (\extension_loaded('gd')) {
+            $img = imagecreatetruecolor(1, 1);
+            imagepng($img, $imagePath);
+            imagedestroy($img);
+        } else {
+            $img = new \Imagick();
+            $img->newImage(1, 1, 'white');
+            $img->setImageFormat('png');
+            $img->writeImage($imagePath);
+            $img->clear();
+        }
 
         $fileName = 'test_image_cell_throws.ods';
         $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -10,7 +10,6 @@ use DateTimeZone;
 use DOMDocument;
 use DOMElement;
 use finfo;
-use Imagick;
 use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Common\Entity\Comment\Comment;
 use OpenSpout\Common\Entity\Comment\TextRun;
@@ -1451,31 +1450,18 @@ final class WriterTest extends TestCase
 
     public function testWriteImageCellEmbedsDrawingFiles(): void
     {
-        if (!\extension_loaded('gd') && !\extension_loaded('imagick')) {
-            self::markTestSkipped('Neither gd nor imagick extension is available.');
-        }
-
+        // Minimal 1×1 image
         $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image.png';
 
         try {
-            if (\extension_loaded('gd')) {
-                $img = imagecreatetruecolor(1, 1);
-                imagepng($img, $imagePath);
-                imagedestroy($img);
-            } else {
-                $img = new Imagick();
-                $img->newImage(1, 1, 'white');
-                $img->setImageFormat('png');
-                $img->writeImage($imagePath);
-                $img->clear();
-            }
+            file_put_contents($imagePath, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg=='));
 
             $fileName = 'test_write_image_cell.xlsx';
             $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
             $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
             $writer = new Writer($options);
             $writer->openToFile($resourcePath);
-            $writer->addRow(new Row([new Cell\ImageCell($imagePath)]));
+            $writer->addRow(new Row([new Cell\ImageCell($imagePath, 1, 1)]));
             $writer->close();
 
             $sheetXml = file_get_contents('zip://'.$resourcePath.'#xl/worksheets/sheet1.xml');

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -19,6 +19,7 @@ use OpenSpout\Common\Exception\IOException;
 use OpenSpout\Reader\Wrapper\XMLReader;
 use OpenSpout\TestUsingResource;
 use OpenSpout\Writer\AutoFilter;
+use OpenSpout\Writer\Common\Helper\ImageHelperTrait;
 use OpenSpout\Writer\Exception\WriterNotOpenedException;
 use OpenSpout\Writer\XLSX\Manager\WorkbookManager;
 use OpenSpout\Writer\XLSX\Options\HeaderFooter;
@@ -43,6 +44,8 @@ use ZipArchive;
  */
 final class WriterTest extends TestCase
 {
+    use ImageHelperTrait;
+
     public function testWriteTextRunFormatting(): void
     {
         $fileName = 'test_text_run_formatting.xlsx';
@@ -1451,94 +1454,76 @@ final class WriterTest extends TestCase
 
     public function testWriteImageCellEmbedsDrawingFiles(): void
     {
-        // Minimal 1×1 image
-        $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image.png';
+        $fileName = 'test_write_image_cell.xlsx';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+        $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+        $writer->addRow(new Row([new Cell\ImageCell($this->testImagePath, 1, 1)]));
+        $writer->close();
 
-        try {
-            file_put_contents($imagePath, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg==', true));
+        $sheetXml = file_get_contents('zip://'.$resourcePath.'#xl/worksheets/sheet1.xml');
+        self::assertNotFalse($sheetXml);
+        self::assertStringContainsString('<drawing r:id="rIdDrawing1"', $sheetXml);
 
-            $fileName = 'test_write_image_cell.xlsx';
-            $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
-            $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
-            $writer = new Writer($options);
-            $writer->openToFile($resourcePath);
-            $writer->addRow(new Row([new Cell\ImageCell($imagePath, 1, 1)]));
-            $writer->close();
+        $drawingXml = file_get_contents('zip://'.$resourcePath.'#xl/drawings/drawing1.xml');
+        self::assertNotFalse($drawingXml, 'Drawing XML file should exist in the archive');
+        self::assertStringContainsString('<xdr:oneCellAnchor>', $drawingXml);
+        self::assertStringContainsString('r:embed="rId1"', $drawingXml);
 
-            $sheetXml = file_get_contents('zip://'.$resourcePath.'#xl/worksheets/sheet1.xml');
-            self::assertNotFalse($sheetXml);
-            self::assertStringContainsString('<drawing r:id="rIdDrawing1"', $sheetXml);
+        $drawingRelsXml = file_get_contents('zip://'.$resourcePath.'#xl/drawings/_rels/drawing1.xml.rels');
+        self::assertNotFalse($drawingRelsXml, 'Drawing rels file should exist in the archive');
+        self::assertStringContainsString('relationships/image', $drawingRelsXml);
+        self::assertStringContainsString('image1.png', $drawingRelsXml);
 
-            $drawingXml = file_get_contents('zip://'.$resourcePath.'#xl/drawings/drawing1.xml');
-            self::assertNotFalse($drawingXml, 'Drawing XML file should exist in the archive');
-            self::assertStringContainsString('<xdr:oneCellAnchor>', $drawingXml);
-            self::assertStringContainsString('r:embed="rId1"', $drawingXml);
+        $contentTypes = file_get_contents('zip://'.$resourcePath.'#[Content_Types].xml');
+        self::assertNotFalse($contentTypes);
+        self::assertStringContainsString('drawing+xml', $contentTypes);
+        self::assertStringContainsString('image/png', $contentTypes);
 
-            $drawingRelsXml = file_get_contents('zip://'.$resourcePath.'#xl/drawings/_rels/drawing1.xml.rels');
-            self::assertNotFalse($drawingRelsXml, 'Drawing rels file should exist in the archive');
-            self::assertStringContainsString('relationships/image', $drawingRelsXml);
-            self::assertStringContainsString('image1.png', $drawingRelsXml);
-
-            $contentTypes = file_get_contents('zip://'.$resourcePath.'#[Content_Types].xml');
-            self::assertNotFalse($contentTypes);
-            self::assertStringContainsString('drawing+xml', $contentTypes);
-            self::assertStringContainsString('image/png', $contentTypes);
-
-            $sheetRels = file_get_contents('zip://'.$resourcePath.'#xl/worksheets/_rels/sheet1.xml.rels');
-            self::assertNotFalse($sheetRels);
-            self::assertStringContainsString('rIdDrawing1', $sheetRels);
-            self::assertStringContainsString('drawings/drawing1.xml', $sheetRels);
-        } finally {
-            unlink($imagePath);
-        }
+        $sheetRels = file_get_contents('zip://'.$resourcePath.'#xl/worksheets/_rels/sheet1.xml.rels');
+        self::assertNotFalse($sheetRels);
+        self::assertStringContainsString('rIdDrawing1', $sheetRels);
+        self::assertStringContainsString('drawings/drawing1.xml', $sheetRels);
     }
 
     public function testDuplicateImageCellIsEmbeddedOnlyOnce(): void
     {
-        // Minimal 1×1 white PNG — no GD or Imagick needed
-        $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image_dedup.png';
+        $fileName = 'test_image_cell_dedup.xlsx';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+        $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+        // Add the same image in two different cells
+        $writer->addRow(new Row([new Cell\ImageCell($this->testImagePath, 1, 1)]));
+        $writer->addRow(new Row([new Cell\ImageCell($this->testImagePath, 1, 1)]));
+        $writer->close();
 
-        try {
-            file_put_contents($imagePath, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg==', true));
+        // The drawing should contain two anchors (one per cell)
+        $drawingXml = file_get_contents('zip://'.$resourcePath.'#xl/drawings/drawing1.xml');
+        self::assertNotFalse($drawingXml);
+        self::assertSame(2, substr_count($drawingXml, '<xdr:oneCellAnchor>'), 'There should be two drawing anchors');
+        // Both anchors must reference the same relationship
+        self::assertSame(2, substr_count($drawingXml, 'r:embed="rId1"'), 'Both anchors should reference rId1');
 
-            $fileName = 'test_image_cell_dedup.xlsx';
-            $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
-            $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
-            $writer = new Writer($options);
-            $writer->openToFile($resourcePath);
-            // Add the same image in two different cells
-            $writer->addRow(new Row([new Cell\ImageCell($imagePath, 1, 1)]));
-            $writer->addRow(new Row([new Cell\ImageCell($imagePath, 1, 1)]));
-            $writer->close();
+        // The drawing rels file must contain exactly one image relationship
+        $drawingRelsXml = file_get_contents('zip://'.$resourcePath.'#xl/drawings/_rels/drawing1.xml.rels');
+        self::assertNotFalse($drawingRelsXml);
+        self::assertSame(1, substr_count($drawingRelsXml, 'relationships/image'), 'The image should only be referenced once in drawing rels');
+        self::assertStringContainsString('image1.png', $drawingRelsXml);
 
-            // The drawing should contain two anchors (one per cell)
-            $drawingXml = file_get_contents('zip://'.$resourcePath.'#xl/drawings/drawing1.xml');
-            self::assertNotFalse($drawingXml);
-            self::assertSame(2, substr_count($drawingXml, '<xdr:oneCellAnchor>'), 'There should be two drawing anchors');
-            // Both anchors must reference the same relationship
-            self::assertSame(2, substr_count($drawingXml, 'r:embed="rId1"'), 'Both anchors should reference rId1');
-
-            // The drawing rels file must contain exactly one image relationship
-            $drawingRelsXml = file_get_contents('zip://'.$resourcePath.'#xl/drawings/_rels/drawing1.xml.rels');
-            self::assertNotFalse($drawingRelsXml);
-            self::assertSame(1, substr_count($drawingRelsXml, 'relationships/image'), 'The image should only be referenced once in drawing rels');
-            self::assertStringContainsString('image1.png', $drawingRelsXml);
-
-            // The archive must contain the media file exactly once
-            $zip = new ZipArchive();
-            $zip->open($resourcePath);
-            $mediaCount = 0;
-            for ($i = 0; $i < $zip->numFiles; ++$i) {
-                $name = $zip->getNameIndex($i);
-                if (false !== $name && str_starts_with($name, 'xl/media/')) {
-                    ++$mediaCount;
-                }
+        // The archive must contain the media file exactly once
+        $zip = new ZipArchive();
+        $zip->open($resourcePath);
+        $mediaCount = 0;
+        for ($i = 0; $i < $zip->numFiles; ++$i) {
+            $name = $zip->getNameIndex($i);
+            if (false !== $name && str_starts_with($name, 'xl/media/')) {
+                ++$mediaCount;
             }
-            $zip->close();
-            self::assertSame(1, $mediaCount, 'The same image should be stored only once in the archive');
-        } finally {
-            unlink($imagePath);
         }
+        $zip->close();
+        self::assertSame(1, $mediaCount, 'The same image should be stored only once in the archive');
     }
 
     /**

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -10,6 +10,7 @@ use DateTimeZone;
 use DOMDocument;
 use DOMElement;
 use finfo;
+use Imagick;
 use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Common\Entity\Comment\Comment;
 use OpenSpout\Common\Entity\Comment\TextRun;
@@ -1462,17 +1463,17 @@ final class WriterTest extends TestCase
                 imagepng($img, $imagePath);
                 imagedestroy($img);
             } else {
-                $img = new \Imagick();
+                $img = new Imagick();
                 $img->newImage(1, 1, 'white');
                 $img->setImageFormat('png');
                 $img->writeImage($imagePath);
                 $img->clear();
             }
 
-            $fileName     = 'test_write_image_cell.xlsx';
+            $fileName = 'test_write_image_cell.xlsx';
             $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
-            $options      = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
-            $writer       = new Writer($options);
+            $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
+            $writer = new Writer($options);
             $writer->openToFile($resourcePath);
             $writer->addRow(new Row([new Cell\ImageCell($imagePath)]));
             $writer->close();

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -36,6 +36,7 @@ use OpenSpout\Writer\XLSX\Validation\ValidationDisplay;
 use OpenSpout\Writer\XLSX\Validation\ValidationOperator;
 use PHPUnit\Framework\TestCase;
 use ReflectionHelper;
+use ZipArchive;
 
 /**
  * @internal
@@ -1454,7 +1455,7 @@ final class WriterTest extends TestCase
         $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image.png';
 
         try {
-            file_put_contents($imagePath, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg=='));
+            file_put_contents($imagePath, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg==', true));
 
             $fileName = 'test_write_image_cell.xlsx';
             $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
@@ -1476,7 +1477,7 @@ final class WriterTest extends TestCase
             $drawingRelsXml = file_get_contents('zip://'.$resourcePath.'#xl/drawings/_rels/drawing1.xml.rels');
             self::assertNotFalse($drawingRelsXml, 'Drawing rels file should exist in the archive');
             self::assertStringContainsString('relationships/image', $drawingRelsXml);
-            self::assertStringContainsString('image1_1.png', $drawingRelsXml);
+            self::assertStringContainsString('image1.png', $drawingRelsXml);
 
             $contentTypes = file_get_contents('zip://'.$resourcePath.'#[Content_Types].xml');
             self::assertNotFalse($contentTypes);
@@ -1487,6 +1488,54 @@ final class WriterTest extends TestCase
             self::assertNotFalse($sheetRels);
             self::assertStringContainsString('rIdDrawing1', $sheetRels);
             self::assertStringContainsString('drawings/drawing1.xml', $sheetRels);
+        } finally {
+            unlink($imagePath);
+        }
+    }
+
+    public function testDuplicateImageCellIsEmbeddedOnlyOnce(): void
+    {
+        // Minimal 1×1 white PNG — no GD or Imagick needed
+        $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image_dedup.png';
+
+        try {
+            file_put_contents($imagePath, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg==', true));
+
+            $fileName = 'test_image_cell_dedup.xlsx';
+            $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+            $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
+            $writer = new Writer($options);
+            $writer->openToFile($resourcePath);
+            // Add the same image in two different cells
+            $writer->addRow(new Row([new Cell\ImageCell($imagePath, 1, 1)]));
+            $writer->addRow(new Row([new Cell\ImageCell($imagePath, 1, 1)]));
+            $writer->close();
+
+            // The drawing should contain two anchors (one per cell)
+            $drawingXml = file_get_contents('zip://'.$resourcePath.'#xl/drawings/drawing1.xml');
+            self::assertNotFalse($drawingXml);
+            self::assertSame(2, substr_count($drawingXml, '<xdr:oneCellAnchor>'), 'There should be two drawing anchors');
+            // Both anchors must reference the same relationship
+            self::assertSame(2, substr_count($drawingXml, 'r:embed="rId1"'), 'Both anchors should reference rId1');
+
+            // The drawing rels file must contain exactly one image relationship
+            $drawingRelsXml = file_get_contents('zip://'.$resourcePath.'#xl/drawings/_rels/drawing1.xml.rels');
+            self::assertNotFalse($drawingRelsXml);
+            self::assertSame(1, substr_count($drawingRelsXml, 'relationships/image'), 'The image should only be referenced once in drawing rels');
+            self::assertStringContainsString('image1.png', $drawingRelsXml);
+
+            // The archive must contain the media file exactly once
+            $zip = new ZipArchive();
+            $zip->open($resourcePath);
+            $mediaCount = 0;
+            for ($i = 0; $i < $zip->numFiles; ++$i) {
+                $name = $zip->getNameIndex($i);
+                if (false !== $name && str_starts_with($name, 'xl/media/')) {
+                    ++$mediaCount;
+                }
+            }
+            $zip->close();
+            self::assertSame(1, $mediaCount, 'The same image should be stored only once in the archive');
         } finally {
             unlink($imagePath);
         }

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -1448,7 +1448,7 @@ final class WriterTest extends TestCase
         self::assertStringNotContainsString('$A$2:$A$10"', $sheet2XmlContents, 'Sheet 2 should not reference sheet 1 range');
     }
 
-    public function testWriteImageCellEmbeddsDrawingFiles(): void
+    public function testWriteImageCellEmbedsDrawingFiles(): void
     {
         if (!\extension_loaded('gd') && !\extension_loaded('imagick')) {
             self::markTestSkipped('Neither gd nor imagick extension is available.');

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -1455,10 +1455,17 @@ final class WriterTest extends TestCase
         }
 
         $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image.png';
-        $img = imagecreatetruecolor(10, 10);
-        \assert(false !== $img);
-        imagepng($img, $imagePath);
-        imagedestroy($img);
+        if (\extension_loaded('gd')) {
+            $img = imagecreatetruecolor(1, 1);
+            imagepng($img, $imagePath);
+            imagedestroy($img);
+        } else {
+            $img = new \Imagick();
+            $img->newImage(1, 1, 'white');
+            $img->setImageFormat('png');
+            $img->writeImage($imagePath);
+            $img->clear();
+        }
 
         $fileName = 'test_write_image_cell.xlsx';
         $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -1448,6 +1448,53 @@ final class WriterTest extends TestCase
         self::assertStringNotContainsString('$A$2:$A$10"', $sheet2XmlContents, 'Sheet 2 should not reference sheet 1 range');
     }
 
+    public function testWriteImageCellEmbeddsDrawingFiles(): void
+    {
+        if (!\extension_loaded('gd') && !\extension_loaded('imagick')) {
+            self::markTestSkipped('Neither gd nor imagick extension is available.');
+        }
+
+        $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image.png';
+        $img = imagecreatetruecolor(10, 10);
+        \assert(false !== $img);
+        imagepng($img, $imagePath);
+        imagedestroy($img);
+
+        $fileName = 'test_write_image_cell.xlsx';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+        $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+        $writer->addRow(new Row([new Cell\ImageCell($imagePath)]));
+        $writer->close();
+
+        $sheetXml = file_get_contents('zip://'.$resourcePath.'#xl/worksheets/sheet1.xml');
+        self::assertNotFalse($sheetXml);
+        self::assertStringContainsString('<drawing r:id="rIdDrawing1"', $sheetXml);
+
+        $drawingXml = file_get_contents('zip://'.$resourcePath.'#xl/drawings/drawing1.xml');
+        self::assertNotFalse($drawingXml, 'Drawing XML file should exist in the archive');
+        self::assertStringContainsString('<xdr:oneCellAnchor>', $drawingXml);
+        self::assertStringContainsString('r:embed="rId1"', $drawingXml);
+
+        $drawingRelsXml = file_get_contents('zip://'.$resourcePath.'#xl/drawings/_rels/drawing1.xml.rels');
+        self::assertNotFalse($drawingRelsXml, 'Drawing rels file should exist in the archive');
+        self::assertStringContainsString('relationships/image', $drawingRelsXml);
+        self::assertStringContainsString('image1_1.png', $drawingRelsXml);
+
+        $contentTypes = file_get_contents('zip://'.$resourcePath.'#[Content_Types].xml');
+        self::assertNotFalse($contentTypes);
+        self::assertStringContainsString('drawing+xml', $contentTypes);
+        self::assertStringContainsString('image/png', $contentTypes);
+
+        $sheetRels = file_get_contents('zip://'.$resourcePath.'#xl/worksheets/_rels/sheet1.xml.rels');
+        self::assertNotFalse($sheetRels);
+        self::assertStringContainsString('rIdDrawing1', $sheetRels);
+        self::assertStringContainsString('drawings/drawing1.xml', $sheetRels);
+
+        unlink($imagePath);
+    }
+
     /**
      * @param Row[] $allRows
      */

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -1455,51 +1455,54 @@ final class WriterTest extends TestCase
         }
 
         $imagePath = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_image.png';
-        if (\extension_loaded('gd')) {
-            $img = imagecreatetruecolor(1, 1);
-            imagepng($img, $imagePath);
-            imagedestroy($img);
-        } else {
-            $img = new \Imagick();
-            $img->newImage(1, 1, 'white');
-            $img->setImageFormat('png');
-            $img->writeImage($imagePath);
-            $img->clear();
+
+        try {
+            if (\extension_loaded('gd')) {
+                $img = imagecreatetruecolor(1, 1);
+                imagepng($img, $imagePath);
+                imagedestroy($img);
+            } else {
+                $img = new \Imagick();
+                $img->newImage(1, 1, 'white');
+                $img->setImageFormat('png');
+                $img->writeImage($imagePath);
+                $img->clear();
+            }
+
+            $fileName     = 'test_write_image_cell.xlsx';
+            $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+            $options      = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
+            $writer       = new Writer($options);
+            $writer->openToFile($resourcePath);
+            $writer->addRow(new Row([new Cell\ImageCell($imagePath)]));
+            $writer->close();
+
+            $sheetXml = file_get_contents('zip://'.$resourcePath.'#xl/worksheets/sheet1.xml');
+            self::assertNotFalse($sheetXml);
+            self::assertStringContainsString('<drawing r:id="rIdDrawing1"', $sheetXml);
+
+            $drawingXml = file_get_contents('zip://'.$resourcePath.'#xl/drawings/drawing1.xml');
+            self::assertNotFalse($drawingXml, 'Drawing XML file should exist in the archive');
+            self::assertStringContainsString('<xdr:oneCellAnchor>', $drawingXml);
+            self::assertStringContainsString('r:embed="rId1"', $drawingXml);
+
+            $drawingRelsXml = file_get_contents('zip://'.$resourcePath.'#xl/drawings/_rels/drawing1.xml.rels');
+            self::assertNotFalse($drawingRelsXml, 'Drawing rels file should exist in the archive');
+            self::assertStringContainsString('relationships/image', $drawingRelsXml);
+            self::assertStringContainsString('image1_1.png', $drawingRelsXml);
+
+            $contentTypes = file_get_contents('zip://'.$resourcePath.'#[Content_Types].xml');
+            self::assertNotFalse($contentTypes);
+            self::assertStringContainsString('drawing+xml', $contentTypes);
+            self::assertStringContainsString('image/png', $contentTypes);
+
+            $sheetRels = file_get_contents('zip://'.$resourcePath.'#xl/worksheets/_rels/sheet1.xml.rels');
+            self::assertNotFalse($sheetRels);
+            self::assertStringContainsString('rIdDrawing1', $sheetRels);
+            self::assertStringContainsString('drawings/drawing1.xml', $sheetRels);
+        } finally {
+            unlink($imagePath);
         }
-
-        $fileName = 'test_write_image_cell.xlsx';
-        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
-        $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
-        $writer = new Writer($options);
-        $writer->openToFile($resourcePath);
-        $writer->addRow(new Row([new Cell\ImageCell($imagePath)]));
-        $writer->close();
-
-        $sheetXml = file_get_contents('zip://'.$resourcePath.'#xl/worksheets/sheet1.xml');
-        self::assertNotFalse($sheetXml);
-        self::assertStringContainsString('<drawing r:id="rIdDrawing1"', $sheetXml);
-
-        $drawingXml = file_get_contents('zip://'.$resourcePath.'#xl/drawings/drawing1.xml');
-        self::assertNotFalse($drawingXml, 'Drawing XML file should exist in the archive');
-        self::assertStringContainsString('<xdr:oneCellAnchor>', $drawingXml);
-        self::assertStringContainsString('r:embed="rId1"', $drawingXml);
-
-        $drawingRelsXml = file_get_contents('zip://'.$resourcePath.'#xl/drawings/_rels/drawing1.xml.rels');
-        self::assertNotFalse($drawingRelsXml, 'Drawing rels file should exist in the archive');
-        self::assertStringContainsString('relationships/image', $drawingRelsXml);
-        self::assertStringContainsString('image1_1.png', $drawingRelsXml);
-
-        $contentTypes = file_get_contents('zip://'.$resourcePath.'#[Content_Types].xml');
-        self::assertNotFalse($contentTypes);
-        self::assertStringContainsString('drawing+xml', $contentTypes);
-        self::assertStringContainsString('image/png', $contentTypes);
-
-        $sheetRels = file_get_contents('zip://'.$resourcePath.'#xl/worksheets/_rels/sheet1.xml.rels');
-        self::assertNotFalse($sheetRels);
-        self::assertStringContainsString('rIdDrawing1', $sheetRels);
-        self::assertStringContainsString('drawings/drawing1.xml', $sheetRels);
-
-        unlink($imagePath);
     }
 
     /**


### PR DESCRIPTION
Regarding https://github.com/openspout/openspout/issues/172, it was easier than I initially thought to implement, so I gave it a try.

## Caveats
- I don't know anything about XLSX; this part is AI-generated.
- Only works for XLSX files for now; (of course, CSV will never be an option.)
- Image is inside the cell (either fitting or with full dimensions) and not absolutely positioned

## Example
```php
<?php

require_once "vendor/autoload.php";

use OpenSpout\Common\Entity\Cell;
use OpenSpout\Common\Entity\Row;
use OpenSpout\Writer\XLSX\Writer;

// Analyze image
$path = 'test.png';
$imagick = new Imagick($path);
$width = $imagick->getImageWidth();
$height = $imagick->getImageHeight();
$imagick->clear();

// Create xlsx
$writer = new Writer;
$writer->openToFile(__DIR__ . '/test.xlsx');

$cells = [
    new Cell\ImageCell(
        path: $path,
        width: $width,
        height: $height,
        fitToCell: true,
    ),
    Cell::fromValue('Carl'),
    Cell::fromValue('is'),
    Cell::fromValue('great!'),
];

$singleRow = new Row($cells);
$writer->addRow($singleRow);

$writer->close();
```