### PR TITLE
Style deduplication in AbstractStyleRegistry uses object identity instead of object content

### DIFF
--- a/src/Writer/Common/Manager/Style/AbstractStyleRegistry.php
+++ b/src/Writer/Common/Manager/Style/AbstractStyleRegistry.php
@@ -33,7 +33,7 @@ abstract class AbstractStyleRegistry
      */
     final public function registerStyle(Style $style): int
     {
-        $serializedStyle = spl_object_hash($style);
+        $serializedStyle = serialize($style);
         if (\array_key_exists($serializedStyle, $this->serializedStyleToStyleIdMappingTable)) {
             return $this->serializedStyleToStyleIdMappingTable[$serializedStyle];
         }

--- a/tests/Writer/ODS/WriterWithStyleTest.php
+++ b/tests/Writer/ODS/WriterWithStyleTest.php
@@ -300,7 +300,7 @@ final class WriterWithStyleTest extends TestCase
 
         $styleElements = $this->getCellStyleElementsFromContentXmlFile($fileName);
 
-        self::assertCount(5, $styleElements);
+        self::assertCount(4, $styleElements);
 
         // Use reflection for protected members here
         $widthMap = BorderHelper::widthMap;
@@ -328,7 +328,7 @@ final class WriterWithStyleTest extends TestCase
             Color::RED
         );
 
-        $actualThird = $styleElements[3]
+        $actualThird = $styleElements[2]
             ->getElementsByTagName('table-cell-properties')
             ->item(0)
             ->getAttribute('fo:border-top')

--- a/tests/Writer/XLSX/Manager/Style/StyleRegistryTest.php
+++ b/tests/Writer/XLSX/Manager/Style/StyleRegistryTest.php
@@ -87,4 +87,18 @@ final class StyleRegistryTest extends TestCase
         self::assertSame(164, $styleRegistry->getFormatIdForStyleId($styleIdUser), 'Second style with user format set should have index 164 (0 is for the default style)');
         self::assertSame(0, $styleRegistry->getFormatIdForStyleId($styleIdNo), 'Style with no format should have index 0');
     }
+
+    public function testDeduplicateEqualStyles(): void
+    {
+        $style_a = new Style(fontBold: true);
+        $styleRegistry = new StyleRegistry($style_a);
+
+        $style_b = new Style(fontBold: true);
+
+        $styleIdA = $styleRegistry->registerStyle($style_a);
+        $styleIdB = $styleRegistry->registerStyle($style_b);
+
+        self::assertCount(1, $styleRegistry->getRegisteredStyles(), 'There should only be 1 registered fill');
+        self::assertEquals($styleIdA, $styleIdB);
+    }
 }


### PR DESCRIPTION
### Problem

When generating large XLSX files, Excel warns about exceeding the unique font limit (32,767). When I checked the generated archive I saw thousands of duplicate `<font>` entries in `xl/styles.xml` — in my case ~73,000 entries for only about 10 distinct fonts.

The cause is in `AbstractStyleRegistry`. The deduplication is keyed on `spl_object_hash($style)`, which is based on the object's identity (memory pointer), not its content. So two `Style` objects that look identical but are different instances both get registered, producing duplicate entries in the output.

### Why this is a problem in v5 specifically

This was introduced in [this commit as part of the v5 update](https://github.com/openspout/openspout/pull/338/changes/0f40edd7eba611e04f44dc8f87e6688a9adf966d), probably for performance — `spl_object_hash` is much cheaper than `serialize`. It works fine if you always reuse the same style instance. But v5 also made `Style` immutable, meaning `with*` methods always return a **new instance**. So `getDefaultStyle()->withFontBold(true)` called twice produces two hashes, two registry entries, two `<font>` elements. The two changes conflict with each other.


### Fix

Replace `spl_object_hash($style)` with `serialize($style)` so deduplication is based on the style's content rather than its instance.

`serialize` is significantly slower than `spl_object_hash` — we're talking nanoseconds vs microseconds per call. On a large file that adds up. But without proper deduplication you end up writing thousands of duplicate `<font>` entries to `styles.xml`, which is far more expensive than the overhead of `serialize`. So the performance tradeoff still favors this fix.

I'd still like to hear the original reasoning for the `spl_object_hash` change — maybe there's something I'm missing. But this fix works for my case and seems correct to me.