### PR TITLE
Fix incorrect ODS column width range handling

### DIFF
--- a/src/Writer/Common/AbstractOptions.php
+++ b/src/Writer/Common/AbstractOptions.php
@@ -73,4 +73,9 @@ abstract readonly class AbstractOptions
     {
         return $this->COLUMN_WIDTHS->get();
     }
+
+    final public function resolveIntervals(): void
+    {
+        $this->COLUMN_WIDTHS->resolveIntervals();
+    }
 }

--- a/src/Writer/Common/ColumnWidthContainer.php
+++ b/src/Writer/Common/ColumnWidthContainer.php
@@ -24,4 +24,81 @@ final class ColumnWidthContainer
     {
         return $this->columnWidths;
     }
+
+    public function resolveIntervals(): void
+    {
+        $segments = $this->buildSegments();
+        $this->columnWidths = $this->mergeAdjacentSegments($segments);
+    }
+
+    /**
+     * @return list<array{start: positive-int, end: positive-int, width: float}>
+     */
+    private function buildSegments(): array
+    {
+        $points = [];
+
+        foreach ($this->columnWidths as $columnWidth) {
+            $points[] = $columnWidth->start;
+            $points[] = $columnWidth->end + 1;
+        }
+
+        sort($points);
+
+        $segments = [];
+        $pointCount = \count($points);
+        for ($pointIndex = 0; $pointIndex < $pointCount - 1; ++$pointIndex) {
+            $segStart = $points[$pointIndex];
+
+            /** @var positive-int $segEnd */
+            $segEnd = $points[$pointIndex + 1] - 1;
+            // Last declared interval wins
+            for ($columnWidthIndex = \count($this->columnWidths) - 1; $columnWidthIndex >= 0; --$columnWidthIndex) {
+                $columnWidth = $this->columnWidths[$columnWidthIndex];
+                if ($columnWidth->start <= $segStart && $columnWidth->end >= $segEnd) {
+                    $segments[] = ['start' => $segStart, 'end' => $segEnd, 'width' => $columnWidth->width];
+
+                    break;
+                }
+            }
+        }
+
+        return $segments;
+    }
+
+    /**
+     * @param list<array{start: positive-int, end: positive-int, width: float}> $segments
+     *
+     * @return list<ColumnWidth>
+     */
+    private function mergeAdjacentSegments(array $segments): array
+    {
+        $mergedSegments = [];
+        foreach ($segments as $segment) {
+            if ([] === $mergedSegments) {
+                $mergedSegments[] = $segment;
+
+                continue;
+            }
+
+            $lastIndex = array_key_last($mergedSegments);
+            $last = &$mergedSegments[$lastIndex];
+
+            $isContinuous = $last['end'] + 1 === $segment['start'];
+            $sameWidth = $last['width'] === $segment['width'];
+
+            if ($isContinuous && $sameWidth) {
+                $last['end'] = $segment['end'];
+            } else {
+                $mergedSegments[] = $segment;
+            }
+        }
+
+        $columnWidths = [];
+        foreach ($mergedSegments as $mergedSegment) {
+            $columnWidths[] = new ColumnWidth($mergedSegment['start'], $mergedSegment['end'], $mergedSegment['width']);
+        }
+
+        return $columnWidths;
+    }
 }

--- a/src/Writer/ODS/Manager/Style/StyleManager.php
+++ b/src/Writer/ODS/Manager/Style/StyleManager.php
@@ -10,7 +10,6 @@ use OpenSpout\Common\Entity\Style\CellAlignment;
 use OpenSpout\Common\Entity\Style\CellVerticalAlignment;
 use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Writer\Common\AbstractOptions;
-use OpenSpout\Writer\Common\ColumnWidth;
 use OpenSpout\Writer\Common\Entity\Worksheet;
 use OpenSpout\Writer\Common\Manager\Style\AbstractStyleManager as CommonStyleManager;
 use OpenSpout\Writer\ODS\Helper\BorderHelper;
@@ -105,11 +104,7 @@ final readonly class StyleManager extends CommonStyleManager
                 EOD;
         }
 
-        // Sort column widths since ODS cares about order
-        $columnWidths = $this->options->getColumnWidths();
-        usort($columnWidths, static function (ColumnWidth $a, ColumnWidth $b): int {
-            return $a->start <=> $b->start;
-        });
+        $this->options->resolveIntervals();
         $content .= $this->getTableColumnStylesXMLContent();
 
         $content .= '</office:automatic-styles>';
@@ -137,21 +132,26 @@ final readonly class StyleManager extends CommonStyleManager
 
     public function getStyledTableColumnXMLContent(int $maxNumColumns): string
     {
-        if ([] === $this->options->getColumnWidths()) {
+        if ([] === ($columnWidths = $this->options->getColumnWidths())) {
             return '';
         }
 
         $content = '';
-        foreach ($this->options->getColumnWidths() as $styleIndex => $columnWidth) {
+        $currentCol = 1;
+        foreach ($columnWidths as $styleIndex => $columnWidth) {
+            if ($currentCol < $columnWidth->start) {
+                $content .= '<table:table-column table:default-cell-style-name="ce1" table:style-name="default-column-style" table:number-columns-repeated="'.($columnWidth->start - $currentCol).'"/>';
+            }
             $numCols = $columnWidth->end - $columnWidth->start + 1;
             $content .= <<<EOD
                 <table:table-column table:default-cell-style-name='Default' table:style-name="co{$styleIndex}" table:number-columns-repeated="{$numCols}"/>
                 EOD;
+            $currentCol = $columnWidth->end + 1;
         }
-        \assert(isset($columnWidth));
-        // Note: This assumes the column widths are contiguous and default width is
-        // only applied to columns after the last custom column with a custom width
-        $content .= '<table:table-column table:default-cell-style-name="ce1" table:style-name="default-column-style" table:number-columns-repeated="'.($maxNumColumns - $columnWidth->end).'"/>';
+
+        if ($currentCol <= $maxNumColumns) {
+            $content .= '<table:table-column table:default-cell-style-name="ce1" table:style-name="default-column-style" table:number-columns-repeated="'.($maxNumColumns - $currentCol + 1).'"/>';
+        }
 
         return $content;
     }

--- a/tests/Writer/ODS/SheetTest.php
+++ b/tests/Writer/ODS/SheetTest.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace OpenSpout\Writer\ODS;
 
 use OpenSpout\Common\Entity\Row;
+use OpenSpout\Common\Exception\IOException;
+use OpenSpout\Reader\Exception\XMLProcessingException;
+use OpenSpout\Reader\Wrapper\XMLReader;
 use OpenSpout\TestUsingResource;
 use OpenSpout\Writer\Common\Entity\Sheet;
 use OpenSpout\Writer\Exception\InvalidSheetNameException;
+use OpenSpout\Writer\Exception\WriterNotOpenedException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -117,6 +122,163 @@ final class SheetTest extends TestCase
         self::assertStringContainsString('style:column-width="100pt"', $xmlContents, 'No cols tag found in sheet');
         self::assertStringContainsString('table:number-columns-repeated="1"', $xmlContents, 'No expected column width definition found in sheet');
         self::assertStringContainsString('table:number-columns-repeated="2"', $xmlContents, 'No expected column width definition found in sheet');
+    }
+
+    /**
+     * @param array<array-key, array{start: positive-int, end: positive-int, width: float}> $rules
+     * @param array<array-key, array{repeated: string, style: string, width?: string}>      $expected
+     *
+     * @throws IOException
+     * @throws XMLProcessingException
+     * @throws WriterNotOpenedException
+     */
+    #[DataProvider('provideWritesColumnWidthsInVariousScenariosCases')]
+    public function testWritesColumnWidthsInVariousScenarios(array $rules, array $expected): void
+    {
+        $fileName = 'test_column_widths_in_various_scensarios.ods';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+
+        $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+        $writer->addRow(Row::fromValues(['ods--11', 'ods--12', 'ods--13', 'ods--14', 'ods--15', 'ods--16']));
+        foreach ($rules as $rule) {
+            $options->setColumnWidthForRange(...$rule);
+        }
+        $writer->close();
+
+        $reader = new XMLReader();
+        $reader->openFileInZip($resourcePath, 'content.xml');
+
+        $styles = [];
+        $columns = [];
+
+        while ($reader->read()) {
+            if (XMLReader::ELEMENT !== $reader->nodeType) {
+                continue;
+            }
+            if ('style:style' === $reader->name
+                && 'table-column' === $reader->getAttribute('style:family')
+                && str_starts_with($styleName = $reader->getAttribute('style:name'), 'co')
+            ) {
+                $styles[$styleName] = $reader->readInnerXml();
+            } elseif ('table:table-column' === $reader->name) {
+                $columns[] = [
+                    'repeated' => $reader->getAttribute('table:number-columns-repeated'),
+                    'style' => $reader->getAttribute('table:style-name'),
+                ];
+            }
+        }
+
+        self::assertCount(\count($expected), $columns);
+
+        foreach ($expected as $index => $expectedAttributes) {
+            self::assertSame($expectedAttributes['repeated'], $columns[$index]['repeated']);
+            self::assertSame($expectedAttributes['style'], $columns[$index]['style']);
+            if (isset($expectedAttributes['width'])) {
+                self::assertStringContainsString(
+                    \sprintf('style:column-width="%s"', $expectedAttributes['width']),
+                    $styles[$expectedAttributes['style']]
+                );
+            }
+        }
+    }
+
+    public static function provideWritesColumnWidthsInVariousScenariosCases(): iterable
+    {
+        return [
+            'partial overlap' => [
+                [
+                    ['start' => 1, 'end' => 10, 'width' => 50.0],
+                    ['start' => 5, 'end' => 7, 'width' => 100.0],
+                ],
+                [
+                    ['repeated' => '4', 'style' => 'co0', 'width' => '50pt'],
+                    ['repeated' => '3', 'style' => 'co1', 'width' => '100pt'],
+                    ['repeated' => '3', 'style' => 'co2', 'width' => '50pt'],
+                ],
+            ],
+
+            'nested overlap' => [
+                [
+                    ['start' => 1, 'end' => 10, 'width' => 50.0],
+                    ['start' => 2, 'end' => 8, 'width' => 100.0],
+                    ['start' => 4, 'end' => 6, 'width' => 80.0],
+                ],
+                [
+                    ['repeated' => '1', 'style' => 'co0', 'width' => '50pt'],
+                    ['repeated' => '2', 'style' => 'co1', 'width' => '100pt'],
+                    ['repeated' => '3', 'style' => 'co2', 'width' => '80pt'],
+                    ['repeated' => '2', 'style' => 'co3', 'width' => '100pt'],
+                    ['repeated' => '2', 'style' => 'co4', 'width' => '50pt'],
+                ],
+            ],
+
+            'no overlap' => [
+                [
+                    ['start' => 1, 'end' => 3, 'width' => 50.0],
+                    ['start' => 5, 'end' => 7, 'width' => 100.0],
+                ],
+                [
+                    ['repeated' => '3', 'style' => 'co0', 'width' => '50pt'],
+                    ['repeated' => '1', 'style' => 'default-column-style'],
+                    ['repeated' => '3', 'style' => 'co1', 'width' => '100pt'],
+                ],
+            ],
+
+            'identical intervals' => [
+                [
+                    ['start' => 1, 'end' => 10, 'width' => 50.0],
+                    ['start' => 1, 'end' => 10, 'width' => 100.0],
+                ],
+                [
+                    ['repeated' => '10', 'style' => 'co0', 'width' => '100pt'],
+                ],
+            ],
+
+            'laster interval contains previous' => [
+                [
+                    ['start' => 5, 'end' => 7, 'width' => 100.0],
+                    ['start' => 1, 'end' => 10, 'width' => 50.0],
+                ],
+                [
+                    ['repeated' => '10', 'style' => 'co0', 'width' => '50pt'],
+                ],
+            ],
+
+            'adjacent intervals' => [
+                [
+                    ['start' => 1, 'end' => 5, 'width' => 50.0],
+                    ['start' => 6, 'end' => 10, 'width' => 100.0],
+                ],
+                [
+                    ['repeated' => '5', 'style' => 'co0', 'width' => '50pt'],
+                    ['repeated' => '5', 'style' => 'co1', 'width' => '100pt'],
+                ],
+            ],
+
+            'boundary overlap' => [
+                [
+                    ['start' => 1, 'end' => 5, 'width' => 50.0],
+                    ['start' => 5, 'end' => 10, 'width' => 100.0],
+                ],
+                [
+                    ['repeated' => '4', 'style' => 'co0', 'width' => '50pt'],
+                    ['repeated' => '6', 'style' => 'co1', 'width' => '100pt'],
+                ],
+            ],
+
+            'single point interval' => [
+                [
+                    ['start' => 5, 'end' => 5, 'width' => 50.0],
+                ],
+                [
+                    ['repeated' => '4', 'style' => 'default-column-style'],
+                    ['repeated' => '1', 'style' => 'co0', 'width' => '50pt'],
+                    ['repeated' => '1', 'style' => 'default-column-style'],
+                ],
+            ],
+        ];
     }
 
     private function writerForFile(string $fileName): Writer


### PR DESCRIPTION
### Summary

Fixes incorrect ODS column width handling when setting a width for a column range.

Previously, the width was applied starting from the left-most column based on the number of columns in the range, instead of respecting the actual start and end column positions.

### Changes

- Fix column range handling logic for ODS width settings
- Add tests covering various column range boundaries
