### PR TITLE
Fix incorrect ODS cell merging for cells with different styles

### DIFF
--- a/src/Writer/ODS/Manager/WorksheetManager.php
+++ b/src/Writer/ODS/Manager/WorksheetManager.php
@@ -105,7 +105,7 @@ final readonly class WorksheetManager implements WorksheetManagerInterface
             $cell = $cells[$currentCellIndex];
             $nextCell = $cells[$nextCellIndex] ?? null;
 
-            if (null === $nextCell || $cell->getValue() !== $nextCell->getValue()) {
+            if (null === $nextCell || $cell->getValue() !== $nextCell->getValue() || $cell->style !== $nextCell->style) {
                 $styleId = 0;
                 if (null !== $cell->style) {
                     $styleId = $this->styleManager->registerStyle($cell->style);

--- a/tests/Writer/ODS/WriterWithStyleTest.php
+++ b/tests/Writer/ODS/WriterWithStyleTest.php
@@ -372,6 +372,38 @@ final class WriterWithStyleTest extends TestCase
         $this->assertFirstChildHasAttributeEquals('#'.Color::GREEN, $customStyleElement, 'text-properties', 'fo:color');
     }
 
+    public function testCellsWithSameValueButDifferentStylesShouldNotBeMerged(): void
+    {
+        $fileName = 'test_add_row_should_apply_cell_alignment.xlsx';
+
+        $greenColorStyle = new Style(fontColor: Color::GREEN);
+        $blueColorStyle = new Style(fontColor: Color::BLUE);
+
+        $rows = [];
+        $rows[] = Row::fromValuesWithStyles(
+            ['ods--same', 'ods--same'],
+            [$greenColorStyle, $blueColorStyle],
+        );
+
+        $this->writeToODSFile($rows, $fileName);
+
+        $cellElements = $this->getCellElementsFromContentXmlFile($fileName);
+        self::assertCount(
+            2,
+            $cellElements,
+            'Cells with different styles should not be merged using number-columns-repeated'
+        );
+
+        self::assertNotEquals(
+            $cellElements[0]->getAttribute('table:style-name'),
+            $cellElements[1]->getAttribute('table:style-name'),
+        );
+
+        self::assertFalse(
+            $cellElements[0]->hasAttribute('table:number-columns-repeated')
+        );
+    }
+
     /**
      * @param Row[] $allRows
      */


### PR DESCRIPTION
### Summary

FIx incorrect ODS cell merging when cells have the same value but different styles.

Previously, `table:number-columns-repeated` was determined only by the cell value, which caused cells with different styles to be merged incorrectly in generated ODS files.

This PR updates the merge condition to also compare cell styles before apply `number-columns-repeated`.

### Changes

- Compare both cell value and style when determining repeated cells
- Prevent merging cells with different styles
- Add regression test for cells with identical values but different styles

### Testing

Added test coverage for:

- cells with same value and different color styles
- correct generation of distinct  ODS cell elements
- prevent of invalid `number-columns-repeated` optimization