### PR TITLE
Fix ODS vertical alignment handling

### DIFF
--- a/src/Writer/ODS/Manager/Style/StyleManager.php
+++ b/src/Writer/ODS/Manager/Style/StyleManager.php
@@ -317,16 +317,12 @@ final readonly class StyleManager extends CommonStyleManager
      */
     private function getParagraphPropertiesSectionContent(Style $style): string
     {
-        if (
-            null === $style->cellAlignment
-            && null === $style->cellVerticalAlignment
-        ) {
+        if (null === $style->cellAlignment) {
             return '';
         }
 
         return '<style:paragraph-properties '
             .$this->getCellAlignmentSectionContent($style)
-            .$this->getCellVerticalAlignmentSectionContent($style)
             .'/>';
     }
 
@@ -355,7 +351,7 @@ final readonly class StyleManager extends CommonStyleManager
         }
 
         return \sprintf(
-            ' fo:vertical-align="%s" ',
+            ' style:vertical-align="%s" ',
             $this->transformCellVerticalAlignment($style->cellVerticalAlignment)
         );
     }
@@ -403,6 +399,8 @@ final readonly class StyleManager extends CommonStyleManager
         if (null !== ($bgColor = $style->backgroundColor)) {
             $content .= $this->getBackgroundColorXMLContent($bgColor);
         }
+
+        $content .= $this->getCellVerticalAlignmentSectionContent($style);
 
         $content .= '/>';
 

--- a/tests/Writer/ODS/WriterWithStyleTest.php
+++ b/tests/Writer/ODS/WriterWithStyleTest.php
@@ -230,7 +230,7 @@ final class WriterWithStyleTest extends TestCase
         self::assertCount(3, $styleElements, 'There should be 3 styles (1 default and 2 custom)');
 
         $customStyleElement = $styleElements[1];
-        $this->assertFirstChildHasAttributeEquals('baseline', $customStyleElement, 'paragraph-properties', 'fo:vertical-align');
+        $this->assertFirstChildHasAttributeEquals('baseline', $customStyleElement, 'table-cell-properties', 'style:vertical-align');
     }
 
     public function testAddRowShouldSupportCellStyling(): void


### PR DESCRIPTION
### Summary

Fix ODS vertical alignment handling in `context.xml`.

Previously, vertical alignment was written to `style:paragraph-properties` using the incorrect attribute `fo:vertical-align`.

This PR update the implementation to write vertical alignment to `style:table-cell-properties` using the correct attribute `style:vertical-align`.

### Changes

- Move vertical alignment handling from `style:paragraph-properties` to `style:table-cell-properties`
- Replace incorrect `fo:vertical-align` with `style:vertical-align`
- Update existing test expectation from `fo:vertical-align` to `style:vertical-align`