### PR TITLE
Add internal SheetViewInterface abstraction and extend sheet view support to ODS

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -142,6 +142,26 @@ $writer = new Writer();
 $writer->getCurrentSheet()->setSheetView($sheetView);
 ```
 
+### Sheet view (ODS writer)
+
+Since ODS view settings are associated with sheet names, the sheet name is required in `ViewSettings`.
+
+```php
+use OpenSpout\Writer\ODS\Entity\ViewSettings;
+use OpenSpout\Writer\ODS\Writer;
+
+$writer = new Writer();
+$sheet = $writer->getCurrentSheet();
+
+$viewSettings = new ViewSettings(
+    $sheet->getName(),
+    freezeRow: 1,
+    freezeColumn: 1,
+    showGrid: false
+);
+$sheet->setSheetView($viewSettings);
+```
+
 ### AutoFilter (XLSX Writer)
 
 AutoFilter can be configured using the `AutoFilter` class:

--- a/src/Writer/Common/Entity/Sheet.php
+++ b/src/Writer/Common/Entity/Sheet.php
@@ -9,7 +9,6 @@ use OpenSpout\Writer\Common\ColumnWidth;
 use OpenSpout\Writer\Common\ColumnWidthContainer;
 use OpenSpout\Writer\Common\Manager\SheetManager;
 use OpenSpout\Writer\Exception\InvalidSheetNameException;
-use OpenSpout\Writer\XLSX\Entity\SheetView;
 use OpenSpout\Writer\XLSX\Options\SheetProtection;
 
 /**
@@ -34,7 +33,7 @@ final class Sheet
     /** @var SheetManager Sheet manager */
     private readonly SheetManager $sheetManager;
 
-    private ?SheetView $sheetView = null;
+    private ?SheetViewInterface $sheetView = null;
 
     /** @var 0|positive-int */
     private int $writtenRowCount = 0;
@@ -131,14 +130,14 @@ final class Sheet
     /**
      * @return $this
      */
-    public function setSheetView(SheetView $sheetView): self
+    public function setSheetView(SheetViewInterface $sheetView): self
     {
         $this->sheetView = $sheetView;
 
         return $this;
     }
 
-    public function getSheetView(): ?SheetView
+    public function getSheetView(): ?SheetViewInterface
     {
         return $this->sheetView;
     }

--- a/src/Writer/Common/Entity/SheetViewInterface.php
+++ b/src/Writer/Common/Entity/SheetViewInterface.php
@@ -12,7 +12,7 @@ interface SheetViewInterface
      * The file format layer is responsible for persisting this value into
      * the target document structure.
      *
-     * @return string Format-specific representation of sheet view settings
+     * @return non-empty-string Format-specific representation of sheet view settings
      */
     public function getXml(): string;
 }

--- a/src/Writer/Common/Entity/SheetViewInterface.php
+++ b/src/Writer/Common/Entity/SheetViewInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSpout\Writer\Common\Entity;
+
+interface SheetViewInterface
+{
+    /**
+     * Returns the format-specific serialization of the sheet view configuration.
+     *
+     * The file format layer is responsible for persisting this value into
+     * the target document structure.
+     *
+     * @return string Format-specific representation of sheet view settings
+     */
+    public function getXml(): string;
+}

--- a/src/Writer/ODS/Entity/ViewSettings.php
+++ b/src/Writer/ODS/Entity/ViewSettings.php
@@ -4,36 +4,21 @@ declare(strict_types=1);
 
 namespace OpenSpout\Writer\ODS\Entity;
 
-use OpenSpout\Common\Exception\InvalidArgumentException;
 use OpenSpout\Writer\Common\Entity\SheetViewInterface;
 
-class ViewSettings implements SheetViewInterface
+final readonly class ViewSettings implements SheetViewInterface
 {
-    /** @var non-negative-int */
-    public int $freezeRow;
-
-    /** @var non-negative-int */
-    public int $freezeColumn;
-
     /**
-     * @throws InvalidArgumentException
+     * @param non-empty-string $sheetName
+     * @param non-negative-int $freezeRow
+     * @param non-negative-int $freezeColumn
      */
     public function __construct(
-        private readonly string $sheetName,
-        int $freezeRow = 0,
-        int $freezeColumn = 0,
+        private string $sheetName,
+        public int $freezeRow = 0,
+        public int $freezeColumn = 0,
         public bool $showGrid = true,
-    ) {
-        if ($freezeRow < 0) {
-            throw new InvalidArgumentException('Freeze row must be a non-negative integer');
-        }
-        $this->freezeRow = $freezeRow;
-
-        if ($freezeColumn < 0) {
-            throw new InvalidArgumentException('Freeze column must be a non-negative integer');
-        }
-        $this->freezeColumn = $freezeColumn;
-    }
+    ) {}
 
     public function getXml(): string
     {

--- a/src/Writer/ODS/Entity/ViewSettings.php
+++ b/src/Writer/ODS/Entity/ViewSettings.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSpout\Writer\ODS\Entity;
+
+use OpenSpout\Common\Exception\InvalidArgumentException;
+use OpenSpout\Writer\Common\Entity\SheetViewInterface;
+
+class ViewSettings implements SheetViewInterface
+{
+    /** @var non-negative-int */
+    public int $freezeRow;
+
+    /** @var non-negative-int */
+    public int $freezeColumn;
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function __construct(
+        private readonly string $sheetName,
+        int $freezeRow = 0,
+        int $freezeColumn = 0,
+        public bool $showGrid = true,
+    ) {
+        if ($freezeRow < 0) {
+            throw new InvalidArgumentException('Freeze row must be a non-negative integer');
+        }
+        $this->freezeRow = $freezeRow;
+
+        if ($freezeColumn < 0) {
+            throw new InvalidArgumentException('Freeze column must be a non-negative integer');
+        }
+        $this->freezeColumn = $freezeColumn;
+    }
+
+    public function getXml(): string
+    {
+        return \sprintf(
+            '<config:config-item-map-entry config:name="%s">%s</config:config-item-map-entry>',
+            $this->sheetName,
+            $this->getConfigItems()
+        );
+    }
+
+    private function getConfigItems(): string
+    {
+        $configItems = $this->getFreezeConfigItemsXml();
+        $configItems .= $this->getShowGridConfigItemsXml();
+
+        return $configItems;
+    }
+
+    private function getFreezeConfigItemsXml(): string
+    {
+        return \sprintf(
+            '
+        <config:config-item config:name="HorizontalSplitMode" config:type="short">2</config:config-item>
+        <config:config-item config:name="VerticalSplitMode" config:type="short">2</config:config-item>
+        <config:config-item config:name="HorizontalSplitPosition" config:type="int">%1$d</config:config-item>
+        <config:config-item config:name="VerticalSplitPosition" config:type="int">%2$d</config:config-item>
+        <config:config-item config:name="PositionLeft" config:type="int">0</config:config-item>
+        <config:config-item config:name="PositionRight" config:type="int">%1$d</config:config-item>
+        <config:config-item config:name="PositionTop" config:type="int">0</config:config-item>
+        <config:config-item config:name="PositionBottom" config:type="int">%2$d</config:config-item>',
+            $this->freezeColumn,
+            $this->freezeRow
+        );
+    }
+
+    private function getShowGridConfigItemsXml(): string
+    {
+        return \sprintf(
+            '<config:config-item config:name="ShowGrid" config:type="boolean">%s</config:config-item>',
+            $this->showGrid ? 'true' : 'false'
+        );
+    }
+}

--- a/src/Writer/ODS/Helper/FileSystemHelper.php
+++ b/src/Writer/ODS/Helper/FileSystemHelper.php
@@ -27,6 +27,7 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
     public const string META_XML_FILE_NAME = 'meta.xml';
     public const string MIMETYPE_FILE_NAME = 'mimetype';
     public const string STYLES_XML_FILE_NAME = 'styles.xml';
+    public const string SETTINGS_XML_FILE_NAME = 'settings.xml';
 
     private string $baseFolderRealPath;
 
@@ -213,6 +214,49 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
     }
 
     /**
+     * Creates the "settings.xml" file under the root folder.
+     *
+     * @param Worksheet[] $worksheets
+     *
+     * @throws IOException
+     */
+    public function createSettingsFile(array $worksheets): self
+    {
+        $settingsXmlFileContents = <<<'EOD'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <office:document-settings xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:ooo="http://openoffice.org/2004/office"
+                xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" office:version="1.3">
+                <office:settings>
+                    <config:config-item-set config:name="ooo:view-settings">
+                        <config:config-item-map-indexed config:name="Views">
+                            <config:config-item-map-entry>
+                                <config:config-item config:name="ViewId" config:type="string">view1</config:config-item>
+                                <config:config-item-map-named config:name="Tables">
+            EOD;
+
+        foreach ($worksheets as $worksheet) {
+            if (null !== ($viewSettings = $worksheet->getExternalSheet()->getSheetView())) {
+                $settingsXmlFileContents .= $viewSettings->getXml();
+            }
+        }
+
+        $settingsXmlFileContents .= <<<'EOD'
+                                </config:config-item-map-named>
+                            </config:config-item-map-entry>
+                        </config:config-item-map-indexed>
+                    </config:config-item-set>
+                </office:settings>
+            </office:document-settings>
+            EOD;
+
+        $this->createFileWithContents($this->rootFolder, self::SETTINGS_XML_FILE_NAME, $settingsXmlFileContents);
+
+        return $this;
+    }
+
+    /**
      * Creates the folder that will be used as root.
      *
      * @throws IOException If unable to create the folder
@@ -252,6 +296,7 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
                 <manifest:file-entry manifest:full-path="styles.xml" manifest:media-type="text/xml"/>
                 <manifest:file-entry manifest:full-path="content.xml" manifest:media-type="text/xml"/>
                 <manifest:file-entry manifest:full-path="meta.xml" manifest:media-type="text/xml"/>
+                <manifest:file-entry manifest:full-path="settings.xml" manifest:media-type="text/xml"/>
             </manifest:manifest>
             EOD;
 

--- a/src/Writer/ODS/Manager/WorkbookManager.php
+++ b/src/Writer/ODS/Manager/WorkbookManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenSpout\Writer\ODS\Manager;
 
+use OpenSpout\Common\Exception\IOException;
 use OpenSpout\Writer\Common\Entity\Workbook;
 use OpenSpout\Writer\Common\Manager\AbstractWorkbookManager;
 use OpenSpout\Writer\ODS\Helper\FileSystemHelper;
@@ -55,6 +56,8 @@ final class WorkbookManager extends AbstractWorkbookManager
      * Writes all the necessary files to disk and zip them together to create the final file.
      *
      * @param resource $finalFilePointer Pointer to the spreadsheet that will be created
+     *
+     * @throws IOException
      */
     protected function writeAllFilesToDiskAndZipThem($finalFilePointer): void
     {
@@ -65,6 +68,7 @@ final class WorkbookManager extends AbstractWorkbookManager
             ->createContentFile($this->worksheetManager, $this->styleManager, $worksheets)
             ->deleteWorksheetTempFolder()
             ->createStylesFile($this->styleManager, $numWorksheets)
+            ->createSettingsFile($worksheets)
             ->zipRootFolderAndCopyToStream($finalFilePointer)
         ;
     }

--- a/src/Writer/XLSX/Entity/SheetView.php
+++ b/src/Writer/XLSX/Entity/SheetView.php
@@ -6,8 +6,9 @@ namespace OpenSpout\Writer\XLSX\Entity;
 
 use OpenSpout\Common\Exception\InvalidArgumentException;
 use OpenSpout\Reader\XLSX\Helper\CellHelper;
+use OpenSpout\Writer\Common\Entity\SheetViewInterface;
 
-final readonly class SheetView
+final readonly class SheetView implements SheetViewInterface
 {
     /**
      * @param non-empty-string $view

--- a/tests/Writer/ODS/ViewSettingsTest.php
+++ b/tests/Writer/ODS/ViewSettingsTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Writer\ODS;
+
+use DOMElement;
+use OpenSpout\Common\Entity\Row;
+use OpenSpout\Reader\Wrapper\XMLReader;
+use OpenSpout\TestUsingResource;
+use OpenSpout\Writer\ODS\Entity\ViewSettings;
+use OpenSpout\Writer\ODS\Writer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class ViewSettingsTest extends TestCase
+{
+    public function testSheetViewSettingsShouldUseDefaultValuesWhenNotExplicitlySet(): void
+    {
+        $fileName = 'test_default_view_settings.ods';
+
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+
+        $writer = new Writer();
+        $writer->openToFile($resourcePath);
+        $writer->addRow(Row::fromValues(['ods--sheet1--11', 'ods--sheet1--12']));
+        $sheet = $writer->getCurrentSheet();
+        $sheet->setSheetView(new ViewSettings($sheet->getName()));
+        $writer->close();
+
+        $this->assertConfigItem($fileName, 'VerticalSplitPosition', '0', 'Default VerticalSplitPosition should be 0');
+        $this->assertConfigItem($fileName, 'HorizontalSplitPosition', '0', 'Default HorizontalSplitPosition should be 0');
+        $this->assertConfigItem($fileName, 'ShowGrid', 'true', 'Default ShowGrid should be true');
+    }
+
+    public function testSheetViewSettingsShouldBePersistedToSettingsXml(): void
+    {
+        $fileName = 'test_explicit_view_settings.ods';
+
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+
+        $writer = new Writer();
+        $writer->openToFile($resourcePath);
+        $writer->addRow(Row::fromValues(['ods--sheet1--11', 'ods--sheet1--12']));
+        $sheet = $writer->getCurrentSheet();
+        $sheet->setSheetView(new ViewSettings($sheet->getName(), 1, 2, false));
+        $writer->close();
+
+        $this->assertConfigItem($fileName, 'VerticalSplitPosition', '1', 'VerticalSplitPosition should be persisted from ViewSettings');
+        $this->assertConfigItem($fileName, 'HorizontalSplitPosition', '2', 'HorizontalSplitPosition should be persisted from ViewSettings');
+        $this->assertConfigItem($fileName, 'ShowGrid', 'false', 'ShowGrid should be persisted from ViewSettings');
+    }
+
+    private function assertConfigItem(string $fileName, string $configName, string $expected, string $message): void
+    {
+        self::assertEquals(
+            $expected,
+            $this->getConfigItemValueFromSettingsXmlFile($fileName, $configName),
+            $message
+        );
+    }
+
+    private function getConfigItemValueFromSettingsXmlFile(string $fileName, string $configName): ?string
+    {
+        $value = null;
+
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+
+        $xmlReader = new XMLReader();
+        $xmlReader->openFileInZip($resourcePath, 'settings.xml');
+
+        while ($xmlReader->read()) {
+            if ($xmlReader->isPositionedOnStartingNode('config:config-item') && $configName === $xmlReader->getAttribute('config:name')) {
+                /** @var DOMElement $element */
+                $element = $xmlReader->expand();
+                $value = $element->nodeValue;
+
+                break;
+            }
+        }
+
+        $xmlReader->close();
+
+        return $value;
+    }
+}

--- a/tests/Writer/ODS/ViewSettingsTest.php
+++ b/tests/Writer/ODS/ViewSettingsTest.php
@@ -27,7 +27,10 @@ class ViewSettingsTest extends TestCase
         $writer->openToFile($resourcePath);
         $writer->addRow(Row::fromValues(['ods--sheet1--11', 'ods--sheet1--12']));
         $sheet = $writer->getCurrentSheet();
-        $sheet->setSheetView(new ViewSettings($sheet->getName()));
+
+        /** @var non-empty-string $sheetName */
+        $sheetName = $sheet->getName();
+        $sheet->setSheetView(new ViewSettings($sheetName));
         $writer->close();
 
         $this->assertConfigItem($fileName, 'VerticalSplitPosition', '0', 'Default VerticalSplitPosition should be 0');
@@ -45,7 +48,10 @@ class ViewSettingsTest extends TestCase
         $writer->openToFile($resourcePath);
         $writer->addRow(Row::fromValues(['ods--sheet1--11', 'ods--sheet1--12']));
         $sheet = $writer->getCurrentSheet();
-        $sheet->setSheetView(new ViewSettings($sheet->getName(), 1, 2, false));
+
+        /** @var non-empty-string $sheetName */
+        $sheetName = $sheet->getName();
+        $sheet->setSheetView(new ViewSettings($sheetName, 1, 2, false));
         $writer->close();
 
         $this->assertConfigItem($fileName, 'VerticalSplitPosition', '1', 'VerticalSplitPosition should be persisted from ViewSettings');


### PR DESCRIPTION
### Summary

Introduce a SheetViewInterface to abstract sheet view serialization
for different spreadsheet formats.

### Changes

- Extract SheetViewInterface from existing XLSX SheetView implementation
- Add ODS ViewSettings implementation
- Both formats now follow a unified serialization contract (getXml)

### Tests

- Added  regression tests for ODS view settings serialization
- Verified settings.xml output correctness