### PR TITLE
fix: guard against invalid stream resource in CommentsManager::closeWorksheetCommentFiles

### DIFF
--- a/src/Writer/XLSX/Manager/CommentsManager.php
+++ b/src/Writer/XLSX/Manager/CommentsManager.php
@@ -108,12 +108,16 @@ final class CommentsManager
         $commentFp = $this->commentsFilePointers[$sheetId];
         $drawingFp = $this->drawingFilePointers[$sheetId];
 
-        fwrite($commentFp, self::COMMENTS_XML_FILE_FOOTER);
-        fwrite($drawingFp, self::DRAWINGS_VML_FILE_FOOTER);
+        if (is_resource($commentFp)) {
+            fwrite($commentFp, self::COMMENTS_XML_FILE_FOOTER);
+            fclose($commentFp);
+        }
 
-        fclose($commentFp);
-        fclose($drawingFp);
-    }
+        if (is_resource($drawingFp)) {
+            fwrite($drawingFp, self::DRAWINGS_VML_FILE_FOOTER);
+            fclose($drawingFp);
+        }
+    }    
 
     public function addComments(Worksheet $worksheet, Row $row): void
     {

--- a/tests/Writer/XLSX/Manager/CommentsManagerTest.php
+++ b/tests/Writer/XLSX/Manager/CommentsManagerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSpout\Writer\XLSX\Manager;
+
+use OpenSpout\Common\Helper\Escaper;
+use OpenSpout\Common\Helper\StringHelper;
+use OpenSpout\Writer\Common\Entity\Sheet;
+use OpenSpout\Writer\Common\Entity\Worksheet;
+use OpenSpout\Writer\Common\Manager\SheetManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CommentsManager::class)]
+final class CommentsManagerTest extends TestCase
+{
+
+    public function test_closeWorksheetCommentFiles_does_not_throw_when_resources_are_invalid(): void
+    {
+        $tempDir = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'openspout_test_'.uniqid();
+        mkdir($tempDir.\DIRECTORY_SEPARATOR.'drawings', 0777, true);
+
+        $manager = new CommentsManager($tempDir, new Escaper\XLSX());
+
+        $sheetManager = new SheetManager(StringHelper::factory());
+        $sheet = new Sheet(0, 'workbook1', $sheetManager);
+        $worksheet = new Worksheet('/tmp/sheet1.xml', $sheet);
+
+        $manager->createWorksheetCommentFiles($worksheet);
+
+        // Simulate PHP shutdown: externally invalidate the stored file handles.
+        $reflection = new \ReflectionClass($manager);
+
+        foreach ($reflection->getProperty('commentsFilePointers')->getValue($manager) as $fp) {
+            if (is_resource($fp)) fclose($fp);
+        }
+        foreach ($reflection->getProperty('drawingFilePointers')->getValue($manager) as $fp) {
+            if (is_resource($fp)) fclose($fp);
+        }
+
+        // Before fix: TypeError — fwrite(): supplied resource is not a valid stream resource
+        // After fix: completes without exception
+        $exceptionThrown = false;
+        try {
+            $manager->closeWorksheetCommentFiles($worksheet);
+        } catch (\TypeError $e) {
+            $exceptionThrown = true;
+        }
+
+        self::assertFalse($exceptionThrown, 'closeWorksheetCommentFiles() should not throw when file handles are no longer valid resources');
+
+        // Cleanup
+        foreach (glob($tempDir.\DIRECTORY_SEPARATOR.'*.xml') ?: [] as $f) @unlink($f);
+        foreach (glob($tempDir.\DIRECTORY_SEPARATOR.'drawings'.\DIRECTORY_SEPARATOR.'*') ?: [] as $f) @unlink($f);
+        @rmdir($tempDir.\DIRECTORY_SEPARATOR.'drawings');
+        @rmdir($tempDir);
+    }
+}


### PR DESCRIPTION
CommentsManager::closeWorksheetCommentFiles() calls fwrite() and fclose() without validating that the stored file pointers are still valid resources. During PHP shutdown (e.g. after a client disconnect), the runtime may free file handles before object destructors execute, leaving the stored pointers in an invalid state.

**Error**
TypeError: fwrite(): supplied resource is not a valid stream resource
at CommentsManager.php:111 (closeWorksheetCommentFiles)
at WorksheetManager.php:105
at AbstractWorkbookManager.php:287 (closeAllWorksheets)
at AbstractWorkbookManager.php:144
at AbstractWriterMultiSheets.php:106 (closeWriter)
at AbstractWriter.php:133 (close)

$writer = new \OpenSpout\Writer\XLSX\Writer();
$writer->openToBrowser('test.xlsx');
$writer->addRow(\OpenSpout\Common\Entity\Row::fromValues(['col1', 'col2']));
// Client disconnects here — PHP shutdown runs, destructor calls close()
// → CommentsManager::closeWorksheetCommentFiles() → fwrite() on freed handle → TypeError

Triggerable by navigating away in the browser during a large/slow export. The HTTP response returns 200 but the error appears in the PHP error log.

**Root cause**

closeWorksheetCommentFiles() retrieves file pointers stored during createWorksheetCommentFiles() but does not verify they are still valid before use. createWorksheetCommentFiles() already uses \assert(false !== $fp) to validate handles on creation — there is no equivalent guard on close.