### PR TITLE
File handle leak when adding multiple sheets via `addNewSheetAndMakeItCurrent()`

### DIFF
--- a/src/Writer/Common/Entity/Worksheet.php
+++ b/src/Writer/Common/Entity/Worksheet.php
@@ -15,7 +15,7 @@ final class Worksheet
     private readonly string $filePath;
 
     /** @var null|resource Pointer to the sheet data file (e.g. xl/worksheets/sheet1.xml) */
-    private $filePointer = null;
+    private $filePointer;
 
     /** @var Sheet The "external" sheet */
     private readonly Sheet $externalSheet;
@@ -48,7 +48,6 @@ final class Worksheet
      */
     public function getFilePointer()
     {
-
         return $this->filePointer;
     }
 

--- a/src/Writer/Common/Entity/Worksheet.php
+++ b/src/Writer/Common/Entity/Worksheet.php
@@ -15,7 +15,7 @@ final class Worksheet
     private readonly string $filePath;
 
     /** @var null|resource Pointer to the sheet data file (e.g. xl/worksheets/sheet1.xml) */
-    private $filePointer;
+    private $filePointer = null;
 
     /** @var Sheet The "external" sheet */
     private readonly Sheet $externalSheet;
@@ -44,17 +44,16 @@ final class Worksheet
     }
 
     /**
-     * @return resource
+     * @return null|resource
      */
     public function getFilePointer()
     {
-        \assert(null !== $this->filePointer);
 
         return $this->filePointer;
     }
 
     /**
-     * @param resource $filePointer
+     * @param null|resource $filePointer
      */
     public function setFilePointer($filePointer): void
     {

--- a/src/Writer/Common/Manager/AbstractWorkbookManager.php
+++ b/src/Writer/Common/Manager/AbstractWorkbookManager.php
@@ -209,7 +209,7 @@ abstract class AbstractWorkbookManager implements WorkbookManagerInterface
     private function setCurrentWorksheet(Worksheet $worksheet): void
     {
         if (isset($this->currentWorksheet) && $this->currentWorksheet !== $worksheet) {
-            $this->worksheetManager->closeSheet($this->currentWorksheet);
+            $this->worksheetManager->suspendSheet($this->currentWorksheet);
         }
         $this->worksheetManager->resumeSheet($worksheet);
         $this->currentWorksheet = $worksheet;

--- a/src/Writer/Common/Manager/AbstractWorkbookManager.php
+++ b/src/Writer/Common/Manager/AbstractWorkbookManager.php
@@ -95,7 +95,7 @@ abstract class AbstractWorkbookManager implements WorkbookManagerInterface
     {
         $worksheet = $this->getWorksheetFromExternalSheet($sheet);
         if (null !== $worksheet) {
-            $this->currentWorksheet = $worksheet;
+            $this->setCurrentWorksheet($worksheet);
         } else {
             throw new SheetNotFoundException('The given sheet does not exist in the workbook.');
         }
@@ -208,6 +208,10 @@ abstract class AbstractWorkbookManager implements WorkbookManagerInterface
 
     private function setCurrentWorksheet(Worksheet $worksheet): void
     {
+        if (isset($this->currentWorksheet) && $this->currentWorksheet !== $worksheet) {
+            $this->worksheetManager->closeSheet($this->currentWorksheet);
+        }
+        $this->worksheetManager->resumeSheet($worksheet);
         $this->currentWorksheet = $worksheet;
     }
 

--- a/src/Writer/Common/Manager/WorksheetManagerInterface.php
+++ b/src/Writer/Common/Manager/WorksheetManagerInterface.php
@@ -40,10 +40,11 @@ interface WorksheetManagerInterface
     public function close(Worksheet $worksheet): void;
 
     /**
-     * Closes the worksheet's file handles without writing footers.
+     * Suspends the worksheet's file handles without writing footers.
      * Used when switching away from a sheet to prevent file handle accumulation.
+     * Counterpart to resumeSheet().
      */
-    public function closeSheet(Worksheet $worksheet): void;
+    public function suspendSheet(Worksheet $worksheet): void;
 
     /**
      * Reopens the worksheet's file handles in append mode.

--- a/src/Writer/Common/Manager/WorksheetManagerInterface.php
+++ b/src/Writer/Common/Manager/WorksheetManagerInterface.php
@@ -38,4 +38,16 @@ interface WorksheetManagerInterface
      * Closes the worksheet.
      */
     public function close(Worksheet $worksheet): void;
+
+    /**
+     * Closes the worksheet's file handles without writing footers.
+     * Used when switching away from a sheet to prevent file handle accumulation.
+     */
+    public function closeSheet(Worksheet $worksheet): void;
+
+    /**
+     * Reopens the worksheet's file handles in append mode.
+     * Used when switching back to a previously closed sheet.
+     */
+    public function resumeSheet(Worksheet $worksheet): void;
 }

--- a/src/Writer/ODS/Manager/WorksheetManager.php
+++ b/src/Writer/ODS/Manager/WorksheetManager.php
@@ -143,7 +143,7 @@ final readonly class WorksheetManager implements WorksheetManagerInterface
         }
     }
 
-    public function closeSheet(Worksheet $worksheet): void
+    public function suspendSheet(Worksheet $worksheet): void
     {
         fclose($worksheet->getFilePointer());
         $worksheet->setFilePointer(null);

--- a/src/Writer/ODS/Manager/WorksheetManager.php
+++ b/src/Writer/ODS/Manager/WorksheetManager.php
@@ -136,7 +136,28 @@ final readonly class WorksheetManager implements WorksheetManagerInterface
      */
     public function close(Worksheet $worksheet): void
     {
+        $fp = $worksheet->getFilePointer();
+        if (null !== $fp) {
+            fclose($fp);
+            $worksheet->setFilePointer(null);
+        }
+    }
+
+    public function closeSheet(Worksheet $worksheet): void
+    {
         fclose($worksheet->getFilePointer());
+        $worksheet->setFilePointer(null);
+    }
+
+    public function resumeSheet(Worksheet $worksheet): void
+    {
+        if (null !== $worksheet->getFilePointer()) {
+            return;
+        }
+
+        $sheetFilePointer = fopen($worksheet->getFilePath(), 'a');
+        \assert(false !== $sheetFilePointer);
+        $worksheet->setFilePointer($sheetFilePointer);
     }
 
     /**

--- a/src/Writer/XLSX/Manager/CommentsManager.php
+++ b/src/Writer/XLSX/Manager/CommentsManager.php
@@ -105,6 +105,10 @@ final class CommentsManager
     {
         $sheetId = $sheet->getId();
 
+        if (!isset($this->commentsFilePointers[$sheetId])) {
+            return;
+        }
+
         $commentFp = $this->commentsFilePointers[$sheetId];
         $drawingFp = $this->drawingFilePointers[$sheetId];
 
@@ -113,6 +117,38 @@ final class CommentsManager
 
         fclose($commentFp);
         fclose($drawingFp);
+
+        unset($this->commentsFilePointers[$sheetId], $this->drawingFilePointers[$sheetId]);
+    }
+
+    /**
+     * Close the two comment-files for the given worksheet without writing footers.
+     * Used when switching away from a sheet to free file handles.
+     */
+    public function closeTempCommentFiles(Worksheet $sheet): void
+    {
+        $sheetId = $sheet->getId();
+
+        if (!isset($this->commentsFilePointers[$sheetId])) {
+            return;
+        }
+
+        fclose($this->commentsFilePointers[$sheetId]);
+        fclose($this->drawingFilePointers[$sheetId]);
+
+        unset($this->commentsFilePointers[$sheetId], $this->drawingFilePointers[$sheetId]);
+    }
+
+    /**
+     * Reopen the two comment-files for the given worksheet in append mode.
+     * Used when switching back to a previously closed sheet.
+     */
+    public function reopenTempCommentFiles(Worksheet $sheet): void
+    {
+        $sheetId = $sheet->getId();
+
+        $this->commentsFilePointers[$sheetId] = fopen($this->getCommentsFilePath($sheet), 'a');
+        $this->drawingFilePointers[$sheetId] = fopen($this->getDrawingFilePath($sheet), 'a');
     }
 
     public function addComments(Worksheet $worksheet, Row $row): void

--- a/src/Writer/XLSX/Manager/CommentsManager.php
+++ b/src/Writer/XLSX/Manager/CommentsManager.php
@@ -147,8 +147,13 @@ final class CommentsManager
     {
         $sheetId = $sheet->getId();
 
-        $this->commentsFilePointers[$sheetId] = fopen($this->getCommentsFilePath($sheet), 'a');
-        $this->drawingFilePointers[$sheetId] = fopen($this->getDrawingFilePath($sheet), 'a');
+        $commentFp = fopen($this->getCommentsFilePath($sheet), 'a');
+        \assert(false !== $commentFp);
+        $drawingFp = fopen($this->getDrawingFilePath($sheet), 'a');
+        \assert(false !== $drawingFp);
+
+        $this->commentsFilePointers[$sheetId] = $commentFp;
+        $this->drawingFilePointers[$sheetId] = $drawingFp;
     }
 
     public function addComments(Worksheet $worksheet, Row $row): void

--- a/src/Writer/XLSX/Manager/WorksheetManager.php
+++ b/src/Writer/XLSX/Manager/WorksheetManager.php
@@ -70,7 +70,30 @@ final readonly class WorksheetManager implements WorksheetManagerInterface
     public function close(Worksheet $worksheet): void
     {
         $this->commentsManager->closeWorksheetCommentFiles($worksheet);
+        $fp = $worksheet->getFilePointer();
+        if (null !== $fp) {
+            fclose($fp);
+            $worksheet->setFilePointer(null);
+        }
+    }
+
+    public function closeSheet(Worksheet $worksheet): void
+    {
+        $this->commentsManager->closeTempCommentFiles($worksheet);
         fclose($worksheet->getFilePointer());
+        $worksheet->setFilePointer(null);
+    }
+
+    public function resumeSheet(Worksheet $worksheet): void
+    {
+        if (null !== $worksheet->getFilePointer()) {
+            return;
+        }
+
+        $sheetFilePointer = fopen($worksheet->getFilePath(), 'a');
+        \assert(false !== $sheetFilePointer);
+        $worksheet->setFilePointer($sheetFilePointer);
+        $this->commentsManager->reopenTempCommentFiles($worksheet);
     }
 
     /**

--- a/src/Writer/XLSX/Manager/WorksheetManager.php
+++ b/src/Writer/XLSX/Manager/WorksheetManager.php
@@ -77,7 +77,7 @@ final readonly class WorksheetManager implements WorksheetManagerInterface
         }
     }
 
-    public function closeSheet(Worksheet $worksheet): void
+    public function suspendSheet(Worksheet $worksheet): void
     {
         $this->commentsManager->closeTempCommentFiles($worksheet);
         fclose($worksheet->getFilePointer());

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -1526,6 +1526,61 @@ final class WriterTest extends TestCase
         self::assertSame(1, $mediaCount, 'The same image should be stored only once in the archive');
     }
 
+    public function testAddNewSheetAndMakeItCurrentLeaksFileHandles(): void
+    {
+        if (!is_dir('/proc/self/fd')) {
+            self::markTestSkipped('This test requires Linux with /proc/self/fd');
+        }
+
+        $fileName = 'test_sheet_file_handle_leak.xlsx';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+        $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+
+        $countFds = function (): int {
+            $fds = scandir('/proc/self/fd');
+            \assert(false !== $fds);
+
+            return \count($fds) - 2; // exclude . and ..
+        };
+
+        $fdsAfterOpen = $countFds();
+
+        $numSheets = 10;
+        for ($i = 0; $i < $numSheets; ++$i) {
+            $writer->addNewSheetAndMakeItCurrent();
+        }
+
+        $fdsAfterAdd = $countFds();
+        $writer->close();
+        $fdsAfterClose = $countFds();
+
+        // Each additional sheet opens 3 file handles (sheet XML, comments XML, drawing VML)
+        // that remain open until close(). The first sheet's handles are already in $fdsAfterOpen.
+        $minimumExpectedIncrease = ($numSheets - 1) * 3;
+        $actualIncrease = $fdsAfterAdd - $fdsAfterOpen;
+
+        self::assertLessThan(
+            $minimumExpectedIncrease,
+            $actualIncrease,
+            \sprintf(
+                'Expected less than %d additional file handles for %d sheets, but got %d. '
+                .'This confirms file handles are recycled (close before switch).',
+                $minimumExpectedIncrease,
+                $numSheets,
+                $actualIncrease,
+            )
+        );
+
+        // After close(), handles must return to near-initial level
+        self::assertLessThanOrEqual(
+            $fdsAfterOpen + 2,
+            $fdsAfterClose,
+            'Writer::close() should release all accumulated file handles'
+        );
+    }
+
     /**
      * @param Row[] $allRows
      */

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -1538,7 +1538,7 @@ final class WriterTest extends TestCase
         $writer = new Writer($options);
         $writer->openToFile($resourcePath);
 
-        $countFds = function (): int {
+        $countFds = static function (): int {
             $fds = scandir('/proc/self/fd');
             \assert(false !== $fds);
 


### PR DESCRIPTION
**Describe the bug**
Every call to addNewSheetAndMakeItCurrent() opens 3 file handles (sheet XML, comments XML, VML drawing) and never closes them until Writer::close(). When many sheets are added this quickly exhausts the OS file descriptor limit, causing EMFILE ("Too many open files").

**Environment**
OpenSpout version: v5.8
PHP: 8.4
OS: Linux (any OS with per-process FD limits; default 1024 on Linux)

**To reproduce**
```bash
git clone https://github.com/vermaysha/openspout-file-description-overflow-repro
cd openspout-file-description-overflow-repro
composer install
php ./src/Repro.test or composer run test
```

Or you can run this code on your existing project

```php
<?php
require_once __DIR__ . '/vendor/autoload.php';

use OpenSpout\Writer\XLSX\Writer;

$countFds = function (): int {
    $fds = scandir('/proc/self/fd');
    \assert(false !== $fds);
    return \count($fds) - 2;
};

$writer = new Writer();
$writer->openToFile('/tmp/fd-leak-test.xlsx');

$initialFds = $countFds();
echo "FD after openToFile: {$initialFds}\n";

for ($i = 0; $i < 20; $i++) {
    $writer->addNewSheetAndMakeItCurrent();
    printf("Sheet %2d → FDs: %d  (Δ: %+d)\n",
        $i + 1, $countFds(), $countFds() - $initialFds);
}

echo "Before close(): {$countFds()}\n";
$writer->close();
echo "After close():  {$countFds()}\n";
```

**Expected behavior (after fix)**
```
FD after openToFile: 6
Sheet  1 → FDs: 6  (Δ: +0)
Sheet  2 → FDs: 6  (Δ: +0)
Sheet  3 → FDs: 6  (Δ: +0)
...
Sheet 20 → FDs: 6  (Δ: +0)
Before close(): 6
After close():  4
```

**Actual behavior (before fix)**
```
FD after openToFile: 6
Sheet  1 → FDs: 9  (Δ: +3)
Sheet  2 → FDs: 9  (Δ: +3)
Sheet  3 → FDs: 12  (Δ: +6)
Sheet  4 → FDs: 15  (Δ: +9)
Sheet  5 → FDs: 18  (Δ: +12)
...
Sheet 20 → FDs: 63  (Δ: +57)
Before close(): 63
After close():  4
```

Each new sheet adds +3 FDs, only reclaimed on Writer::close(). With the default 1024 FD limit, a crash occurs at ~340 sheets (1024 ÷ 3).

**Root cause**
`AbstractWorkbookManager::addNewSheet()` calls `WorksheetManager::startSheet()` which opens 3 file pointers (sheet XML, comments XML, VML drawing). When switching sheets via `setCurrentSheet()`/`addNewSheetAndMakeItCurrent()`, the old sheet's handles remain open. Only `Writer::close()` → `closeAllWorksheets()` eventually closes them.

Fix
Introduce `closeSheet()`/`resumeSheet()` on `WorksheetManagerInterface`:
1. On sheet switch, close previous sheet's handles without writing XML footers
2. Reopen target sheet's handles in append mode
3. 6 files modified (interface, XLSX & ODS worksheet managers, comments manager, workbook manager)

**The test cases have been created, and all of them have passed.**