### PR TITLE
Add hidden, collapsed and outline-level column support (XLSX + ODS)

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -296,6 +296,49 @@ foreach ($reader->getSheetIterator() as $sheet) {
 }
 ```
 
+## Hidden, collapsed and outline-level columns
+
+Columns can be hidden, marked as collapsed, or assigned an outline (grouping)
+level. These attributes are set at the **sheet** level and work for both the XLSX
+and ODS writers. Column indexes are 1-based, and each setter accepts either a list
+of columns or a range.
+
+```php
+use OpenSpout\Common\Entity\Row;
+use OpenSpout\Writer\XLSX\Writer;
+
+$writer = new Writer();
+$writer->openToFile('/tmp/file.xlsx');
+$writer->addRow(Row::fromValues(['foo', 'bar', 'baz', 'qux']));
+
+$sheet = $writer->getCurrentSheet();
+
+// Hide a single column, several columns, or a range at once
+$sheet->setColumnHidden(true, 1);
+$sheet->setColumnHiddenForRange(true, 2, 3);
+
+// Mark columns as collapsed
+$sheet->setColumnCollapsed(true, 4);
+
+// Assign an outline (grouping) level (0-7)
+$sheet->setColumnOutlineLevel(1, 5);
+$sheet->setColumnOutlineLevelForRange(1, 6, 7);
+
+$writer->close();
+```
+
+Widths, hidden, collapsed and outline-level attributes are combined into minimal
+`<col>` ranges for XLSX. For ODS, hidden and collapsed columns are written with
+`table:visibility="collapse"`; note that ODS **outline-level grouping is not yet
+supported** and is ignored for ODS output.
+
+The declared values can also be read back from the sheet before closing:
+
+```php
+$sheet->getColumnHiddens();       // list of OpenSpout\Writer\Common\ColumnHidden
+$sheet->getColumnCollapseds();    // list of OpenSpout\Writer\Common\ColumnCollapsed
+$sheet->getColumnOutlineLevels(); // list of OpenSpout\Writer\Common\ColumnOutlineLevel
+```
 
 ## Cell merging
 

--- a/src/Writer/Common/ColumnAttributesResolver.php
+++ b/src/Writer/Common/ColumnAttributesResolver.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSpout\Writer\Common;
+
+use OpenSpout\Writer\Common\Entity\Sheet;
+
+/**
+ * Combines the independent per-attribute declarations of a sheet (widths, hidden,
+ * collapsed and outline-level) into a minimal list of column ranges, each sharing
+ * an identical set of effective attributes. Overlapping declarations resolve with
+ * "last declared wins", matching ColumnWidthContainer.
+ *
+ * @internal
+ */
+final readonly class ColumnAttributesResolver
+{
+    /**
+     * @return list<ResolvedColumn>
+     */
+    public function resolve(Sheet $sheet): array
+    {
+        $widths = $sheet->getColumnWidths();
+        $hiddens = $sheet->getColumnHiddens();
+        $collapseds = $sheet->getColumnCollapseds();
+        $levels = $sheet->getColumnOutlineLevels();
+
+        /** @var array<positive-int, true> $touched */
+        $touched = [];
+        $minCol = null;
+        $maxCol = 0;
+        foreach ([$widths, $hiddens, $collapseds, $levels] as $entries) {
+            foreach ($entries as $entry) {
+                for ($column = $entry->start; $column <= $entry->end; ++$column) {
+                    $touched[$column] = true;
+                }
+                $minCol = null === $minCol ? $entry->start : min($minCol, $entry->start);
+                $maxCol = max($maxCol, $entry->end);
+            }
+        }
+
+        if (null === $minCol) {
+            return [];
+        }
+
+        $resolved = [];
+
+        /** @var null|array{start: positive-int, end: positive-int, width: ?float, hidden: ?bool, collapsed: ?bool, level: null|int<0, 7>} $pending */
+        $pending = null;
+
+        for ($column = $minCol; $column <= $maxCol; ++$column) {
+            if (!isset($touched[$column])) {
+                // Gap between declared columns breaks the current run
+                if (null !== $pending) {
+                    $resolved[] = new ResolvedColumn($pending['start'], $pending['end'], $pending['width'], $pending['hidden'], $pending['collapsed'], $pending['level']);
+                    $pending = null;
+                }
+
+                continue;
+            }
+
+            $width = self::effectiveWidth($widths, $column);
+            $hidden = self::effectiveHidden($hiddens, $column);
+            $collapsed = self::effectiveCollapsed($collapseds, $column);
+            $level = self::effectiveOutlineLevel($levels, $column);
+
+            if (
+                null !== $pending
+                && $pending['end'] + 1 === $column
+                && $width === $pending['width']
+                && $hidden === $pending['hidden']
+                && $collapsed === $pending['collapsed']
+                && $level === $pending['level']
+            ) {
+                $pending['end'] = $column;
+
+                continue;
+            }
+
+            if (null !== $pending) {
+                $resolved[] = new ResolvedColumn($pending['start'], $pending['end'], $pending['width'], $pending['hidden'], $pending['collapsed'], $pending['level']);
+            }
+
+            $pending = [
+                'start' => $column,
+                'end' => $column,
+                'width' => $width,
+                'hidden' => $hidden,
+                'collapsed' => $collapsed,
+                'level' => $level,
+            ];
+        }
+
+        if (null !== $pending) {
+            $resolved[] = new ResolvedColumn($pending['start'], $pending['end'], $pending['width'], $pending['hidden'], $pending['collapsed'], $pending['level']);
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param list<ColumnWidth> $entries
+     * @param positive-int      $column
+     */
+    private static function effectiveWidth(array $entries, int $column): ?float
+    {
+        for ($index = \count($entries) - 1; $index >= 0; --$index) {
+            $entry = $entries[$index];
+            if ($entry->start <= $column && $entry->end >= $column) {
+                return $entry->width;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<ColumnHidden> $entries
+     * @param positive-int       $column
+     */
+    private static function effectiveHidden(array $entries, int $column): ?bool
+    {
+        for ($index = \count($entries) - 1; $index >= 0; --$index) {
+            $entry = $entries[$index];
+            if ($entry->start <= $column && $entry->end >= $column) {
+                return $entry->hidden;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<ColumnCollapsed> $entries
+     * @param positive-int          $column
+     */
+    private static function effectiveCollapsed(array $entries, int $column): ?bool
+    {
+        for ($index = \count($entries) - 1; $index >= 0; --$index) {
+            $entry = $entries[$index];
+            if ($entry->start <= $column && $entry->end >= $column) {
+                return $entry->collapsed;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<ColumnOutlineLevel> $entries
+     * @param positive-int             $column
+     *
+     * @return null|int<0, 7>
+     */
+    private static function effectiveOutlineLevel(array $entries, int $column): ?int
+    {
+        for ($index = \count($entries) - 1; $index >= 0; --$index) {
+            $entry = $entries[$index];
+            if ($entry->start <= $column && $entry->end >= $column) {
+                return $entry->level;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Writer/Common/ColumnCollapsed.php
+++ b/src/Writer/Common/ColumnCollapsed.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSpout\Writer\Common;
+
+/**
+ * @internal
+ */
+final readonly class ColumnCollapsed
+{
+    /**
+     * @param positive-int $start
+     * @param positive-int $end
+     */
+    public function __construct(
+        public int $start,
+        public int $end,
+        public bool $collapsed,
+    ) {}
+}

--- a/src/Writer/Common/ColumnCollapsedContainer.php
+++ b/src/Writer/Common/ColumnCollapsedContainer.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSpout\Writer\Common;
+
+/**
+ * @internal
+ */
+final class ColumnCollapsedContainer
+{
+    /** @var list<ColumnCollapsed> */
+    private array $columnCollapseds = [];
+
+    public function append(ColumnCollapsed $columnCollapsed): void
+    {
+        $this->columnCollapseds[] = $columnCollapsed;
+    }
+
+    /**
+     * @return list<ColumnCollapsed>
+     */
+    public function get(): array
+    {
+        return $this->columnCollapseds;
+    }
+}

--- a/src/Writer/Common/ColumnHidden.php
+++ b/src/Writer/Common/ColumnHidden.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSpout\Writer\Common;
+
+/**
+ * @internal
+ */
+final readonly class ColumnHidden
+{
+    /**
+     * @param positive-int $start
+     * @param positive-int $end
+     */
+    public function __construct(
+        public int $start,
+        public int $end,
+        public bool $hidden,
+    ) {}
+}

--- a/src/Writer/Common/ColumnHiddenContainer.php
+++ b/src/Writer/Common/ColumnHiddenContainer.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSpout\Writer\Common;
+
+/**
+ * @internal
+ */
+final class ColumnHiddenContainer
+{
+    /** @var list<ColumnHidden> */
+    private array $columnHiddens = [];
+
+    public function append(ColumnHidden $columnHidden): void
+    {
+        $this->columnHiddens[] = $columnHidden;
+    }
+
+    /**
+     * @return list<ColumnHidden>
+     */
+    public function get(): array
+    {
+        return $this->columnHiddens;
+    }
+}

--- a/src/Writer/Common/ColumnOutlineLevel.php
+++ b/src/Writer/Common/ColumnOutlineLevel.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSpout\Writer\Common;
+
+/**
+ * @internal
+ */
+final readonly class ColumnOutlineLevel
+{
+    /**
+     * @param positive-int $start
+     * @param positive-int $end
+     * @param int<0, 7>    $level
+     */
+    public function __construct(
+        public int $start,
+        public int $end,
+        public int $level,
+    ) {}
+}

--- a/src/Writer/Common/ColumnOutlineLevelContainer.php
+++ b/src/Writer/Common/ColumnOutlineLevelContainer.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSpout\Writer\Common;
+
+/**
+ * @internal
+ */
+final class ColumnOutlineLevelContainer
+{
+    /** @var list<ColumnOutlineLevel> */
+    private array $columnOutlineLevels = [];
+
+    public function append(ColumnOutlineLevel $columnOutlineLevel): void
+    {
+        $this->columnOutlineLevels[] = $columnOutlineLevel;
+    }
+
+    /**
+     * @return list<ColumnOutlineLevel>
+     */
+    public function get(): array
+    {
+        return $this->columnOutlineLevels;
+    }
+}

--- a/src/Writer/Common/Entity/Sheet.php
+++ b/src/Writer/Common/Entity/Sheet.php
@@ -5,6 +5,12 @@ declare(strict_types=1);
 namespace OpenSpout\Writer\Common\Entity;
 
 use OpenSpout\Writer\AutoFilter;
+use OpenSpout\Writer\Common\ColumnCollapsed;
+use OpenSpout\Writer\Common\ColumnCollapsedContainer;
+use OpenSpout\Writer\Common\ColumnHidden;
+use OpenSpout\Writer\Common\ColumnHiddenContainer;
+use OpenSpout\Writer\Common\ColumnOutlineLevel;
+use OpenSpout\Writer\Common\ColumnOutlineLevelContainer;
 use OpenSpout\Writer\Common\ColumnWidth;
 use OpenSpout\Writer\Common\ColumnWidthContainer;
 use OpenSpout\Writer\Common\Manager\SheetManager;
@@ -42,6 +48,12 @@ final class Sheet
 
     private ColumnWidthContainer $COLUMN_WIDTHS;
 
+    private ColumnHiddenContainer $COLUMN_HIDDEN;
+
+    private ColumnCollapsedContainer $COLUMN_COLLAPSED;
+
+    private ColumnOutlineLevelContainer $COLUMN_OUTLINE_LEVEL;
+
     /** @var string rows to repeat at top */
     private ?string $printTitleRows = null;
 
@@ -64,6 +76,9 @@ final class Sheet
         $this->setIsVisible(true);
 
         $this->COLUMN_WIDTHS = new ColumnWidthContainer();
+        $this->COLUMN_HIDDEN = new ColumnHiddenContainer();
+        $this->COLUMN_COLLAPSED = new ColumnCollapsedContainer();
+        $this->COLUMN_OUTLINE_LEVEL = new ColumnOutlineLevelContainer();
     }
 
     /**
@@ -178,20 +193,9 @@ final class Sheet
      */
     public function setColumnWidth(float $width, int ...$columns): void
     {
-        // Gather sequences
-        $sequence = [];
-        foreach ($columns as $column) {
-            $sequenceLength = \count($sequence);
-            if ($sequenceLength > 0) {
-                $previousValue = $sequence[$sequenceLength - 1];
-                if ($column !== $previousValue + 1) {
-                    $this->setColumnWidthForRange($width, $sequence[0], $previousValue);
-                    $sequence = [];
-                }
-            }
-            $sequence[] = $column;
+        foreach (self::gatherRanges($columns) as [$start, $end]) {
+            $this->setColumnWidthForRange($width, $start, $end);
         }
-        $this->setColumnWidthForRange($width, $sequence[0], $sequence[\count($sequence) - 1]);
     }
 
     /**
@@ -212,6 +216,95 @@ final class Sheet
     public function getColumnWidths(): array
     {
         return $this->COLUMN_WIDTHS->get();
+    }
+
+    /**
+     * @param positive-int ...$columns One or more columns to hide (or unhide)
+     */
+    public function setColumnHidden(bool $hidden, int ...$columns): void
+    {
+        foreach (self::gatherRanges($columns) as [$start, $end]) {
+            $this->setColumnHiddenForRange($hidden, $start, $end);
+        }
+    }
+
+    /**
+     * @param positive-int $start First column index of the range
+     * @param positive-int $end   Last column index of the range
+     */
+    public function setColumnHiddenForRange(bool $hidden, int $start, int $end): void
+    {
+        $this->COLUMN_HIDDEN->append(new ColumnHidden($start, $end, $hidden));
+    }
+
+    /**
+     * @internal
+     *
+     * @return list<ColumnHidden>
+     */
+    public function getColumnHiddens(): array
+    {
+        return $this->COLUMN_HIDDEN->get();
+    }
+
+    /**
+     * @param positive-int ...$columns One or more columns to mark collapsed (or expanded)
+     */
+    public function setColumnCollapsed(bool $collapsed, int ...$columns): void
+    {
+        foreach (self::gatherRanges($columns) as [$start, $end]) {
+            $this->setColumnCollapsedForRange($collapsed, $start, $end);
+        }
+    }
+
+    /**
+     * @param positive-int $start First column index of the range
+     * @param positive-int $end   Last column index of the range
+     */
+    public function setColumnCollapsedForRange(bool $collapsed, int $start, int $end): void
+    {
+        $this->COLUMN_COLLAPSED->append(new ColumnCollapsed($start, $end, $collapsed));
+    }
+
+    /**
+     * @internal
+     *
+     * @return list<ColumnCollapsed>
+     */
+    public function getColumnCollapseds(): array
+    {
+        return $this->COLUMN_COLLAPSED->get();
+    }
+
+    /**
+     * @param int<0, 7>    $level      Outline (group) level to apply
+     * @param positive-int ...$columns One or more columns with this outline level
+     */
+    public function setColumnOutlineLevel(int $level, int ...$columns): void
+    {
+        foreach (self::gatherRanges($columns) as [$start, $end]) {
+            $this->setColumnOutlineLevelForRange($level, $start, $end);
+        }
+    }
+
+    /**
+     * @param int<0, 7>    $level Outline (group) level to apply
+     * @param positive-int $start First column index of the range
+     * @param positive-int $end   Last column index of the range
+     */
+    public function setColumnOutlineLevelForRange(int $level, int $start, int $end): void
+    {
+        $this->COLUMN_OUTLINE_LEVEL->append(new ColumnOutlineLevel($start, $end, $level));
+    }
+
+    /**
+     * @internal
+     *
+     * @return list<ColumnOutlineLevel>
+     */
+    public function getColumnOutlineLevels(): array
+    {
+        return $this->COLUMN_OUTLINE_LEVEL->get();
     }
 
     public function getPrintTitleRows(): ?string
@@ -237,5 +330,34 @@ final class Sheet
     public function getSheetProtection(): ?SheetProtection
     {
         return $this->sheetProtection;
+    }
+
+    /**
+     * Collapses a list of column indexes into contiguous [start, end] ranges.
+     *
+     * @param array<positive-int> $columns
+     *
+     * @return list<array{positive-int, positive-int}>
+     */
+    private static function gatherRanges(array $columns): array
+    {
+        $ranges = [];
+        $sequence = [];
+        foreach ($columns as $column) {
+            $sequenceLength = \count($sequence);
+            if ($sequenceLength > 0) {
+                $previousValue = $sequence[$sequenceLength - 1];
+                if ($column !== $previousValue + 1) {
+                    $ranges[] = [$sequence[0], $previousValue];
+                    $sequence = [];
+                }
+            }
+            $sequence[] = $column;
+        }
+        if ([] !== $sequence) {
+            $ranges[] = [$sequence[0], $sequence[\count($sequence) - 1]];
+        }
+
+        return $ranges;
     }
 }

--- a/src/Writer/Common/ResolvedColumn.php
+++ b/src/Writer/Common/ResolvedColumn.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSpout\Writer\Common;
+
+/**
+ * A range of adjacent columns sharing an identical set of column attributes,
+ * ready to be written as a single "<col>" element.
+ *
+ * @internal
+ */
+final readonly class ResolvedColumn
+{
+    /**
+     * @param positive-int $start
+     * @param positive-int $end
+     * @param int<0, 7>    $outlineLevel
+     */
+    public function __construct(
+        public int $start,
+        public int $end,
+        public ?float $width,
+        public ?bool $hidden,
+        public ?bool $collapsed,
+        public ?int $outlineLevel,
+    ) {}
+}

--- a/src/Writer/ODS/Manager/Style/StyleManager.php
+++ b/src/Writer/ODS/Manager/Style/StyleManager.php
@@ -10,6 +10,8 @@ use OpenSpout\Common\Entity\Style\CellAlignment;
 use OpenSpout\Common\Entity\Style\CellVerticalAlignment;
 use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Writer\Common\AbstractOptions;
+use OpenSpout\Writer\Common\ColumnAttributesResolver;
+use OpenSpout\Writer\Common\Entity\Sheet;
 use OpenSpout\Writer\Common\Entity\Worksheet;
 use OpenSpout\Writer\Common\Manager\Style\AbstractStyleManager as CommonStyleManager;
 use OpenSpout\Writer\ODS\Helper\BorderHelper;
@@ -130,9 +132,12 @@ final readonly class StyleManager extends CommonStyleManager
         return $content;
     }
 
-    public function getStyledTableColumnXMLContent(int $maxNumColumns): string
+    public function getStyledTableColumnXMLContent(int $maxNumColumns, Sheet $sheet): string
     {
-        if ([] === ($columnWidths = $this->options->getColumnWidths())) {
+        $columnWidths = $this->options->getColumnWidths();
+        $collapsedColumns = self::buildCollapsedColumnMap($sheet);
+
+        if ([] === $columnWidths && [] === $collapsedColumns) {
             return '';
         }
 
@@ -140,20 +145,67 @@ final readonly class StyleManager extends CommonStyleManager
         $currentCol = 1;
         foreach ($columnWidths as $styleIndex => $columnWidth) {
             if ($currentCol < $columnWidth->start) {
-                $content .= '<table:table-column table:default-cell-style-name="ce1" table:style-name="default-column-style" table:number-columns-repeated="'.($columnWidth->start - $currentCol).'"/>';
+                $content .= self::renderTableColumns('"ce1"', 'default-column-style', $currentCol, $columnWidth->start - $currentCol, $collapsedColumns);
             }
             $numCols = $columnWidth->end - $columnWidth->start + 1;
-            $content .= <<<EOD
-                <table:table-column table:default-cell-style-name='Default' table:style-name="co{$styleIndex}" table:number-columns-repeated="{$numCols}"/>
-                EOD;
+            $content .= self::renderTableColumns("'Default'", 'co'.$styleIndex, $columnWidth->start, $numCols, $collapsedColumns);
             $currentCol = $columnWidth->end + 1;
         }
 
         if ($currentCol <= $maxNumColumns) {
-            $content .= '<table:table-column table:default-cell-style-name="ce1" table:style-name="default-column-style" table:number-columns-repeated="'.($maxNumColumns - $currentCol + 1).'"/>';
+            $content .= self::renderTableColumns('"ce1"', 'default-column-style', $currentCol, $maxNumColumns - $currentCol + 1, $collapsedColumns);
         }
 
         return $content;
+    }
+
+    /**
+     * Splits a run of columns sharing a style into "<table:table-column>" elements,
+     * adding table:visibility="collapse" to the sub-runs that are hidden or collapsed.
+     *
+     * @param string                    $defaultCellStyle Quoted table:default-cell-style-name value (e.g. "'Default'")
+     * @param positive-int              $startCol
+     * @param array<positive-int, true> $collapsedColumns
+     */
+    private static function renderTableColumns(string $defaultCellStyle, string $styleName, int $startCol, int $count, array $collapsedColumns): string
+    {
+        $content = '';
+        $endCol = $startCol + $count - 1;
+        $runStart = $startCol;
+        for ($column = $startCol; $column <= $endCol; ++$column) {
+            $runEnds = $column === $endCol
+                || isset($collapsedColumns[$column]) !== isset($collapsedColumns[$column + 1]);
+            if (!$runEnds) {
+                continue;
+            }
+            $repeated = $column - $runStart + 1;
+            $visibility = isset($collapsedColumns[$runStart]) ? ' table:visibility="collapse"' : '';
+            $content .= '<table:table-column table:default-cell-style-name='.$defaultCellStyle.' table:style-name="'.$styleName.'"'.$visibility.' table:number-columns-repeated="'.$repeated.'"/>';
+            $runStart = $column + 1;
+        }
+
+        return $content;
+    }
+
+    /**
+     * Builds the set of columns that must be visually collapsed in ODS
+     * (hidden and collapsed both map to table:visibility="collapse").
+     *
+     * @return array<positive-int, true>
+     */
+    private static function buildCollapsedColumnMap(Sheet $sheet): array
+    {
+        $collapsedColumns = [];
+        foreach ((new ColumnAttributesResolver())->resolve($sheet) as $resolvedColumn) {
+            if (true !== $resolvedColumn->hidden && true !== $resolvedColumn->collapsed) {
+                continue;
+            }
+            for ($column = $resolvedColumn->start; $column <= $resolvedColumn->end; ++$column) {
+                $collapsedColumns[$column] = true;
+            }
+        }
+
+        return $collapsedColumns;
     }
 
     /**

--- a/src/Writer/ODS/Manager/WorksheetManager.php
+++ b/src/Writer/ODS/Manager/WorksheetManager.php
@@ -54,7 +54,7 @@ final readonly class WorksheetManager implements WorksheetManagerInterface
         $tableStyleName = 'ta'.($externalSheet->getIndex() + 1);
 
         $tableElement = '<table:table table:style-name="'.$tableStyleName.'" table:name="'.$escapedSheetName.'">';
-        $tableElement .= $this->styleManager->getStyledTableColumnXMLContent($worksheet->getMaxNumColumns());
+        $tableElement .= $this->styleManager->getStyledTableColumnXMLContent($worksheet->getMaxNumColumns(), $externalSheet);
 
         return $tableElement;
     }

--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -9,6 +9,7 @@ use OpenSpout\Common\Entity\Cell\ImageCell;
 use OpenSpout\Common\Exception\IOException;
 use OpenSpout\Common\Helper\Escaper\XLSX;
 use OpenSpout\Common\Helper\FileSystemHelper as CommonFileSystemHelper;
+use OpenSpout\Writer\Common\ColumnAttributesResolver;
 use OpenSpout\Writer\Common\Entity\Sheet;
 use OpenSpout\Writer\Common\Entity\Worksheet;
 use OpenSpout\Writer\Common\Helper\CellHelper;
@@ -632,6 +633,14 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
      */
     private function getXMLFragmentForColumnWidths(Options $options, Sheet $sheet): string
     {
+        $hasVisibilityAttributes = [] !== $sheet->getColumnHiddens()
+            || [] !== $sheet->getColumnCollapseds()
+            || [] !== $sheet->getColumnOutlineLevels();
+
+        if ($hasVisibilityAttributes) {
+            return $this->getXMLFragmentForResolvedColumns($sheet);
+        }
+
         if ([] !== $sheet->getColumnWidths()) {
             $widths = $sheet->getColumnWidths();
         } elseif ([] !== $options->getColumnWidths()) {
@@ -644,6 +653,39 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
 
         foreach ($widths as $columnWidth) {
             $xml .= '<col min="'.$columnWidth->start.'" max="'.$columnWidth->end.'" width="'.$columnWidth->width.'" customWidth="true"/>';
+        }
+        $xml .= '</cols>';
+
+        return $xml;
+    }
+
+    /**
+     * Construct column xml combining width, hidden, collapsed and outline-level
+     * attributes into coalesced "<col>" ranges.
+     */
+    private function getXMLFragmentForResolvedColumns(Sheet $sheet): string
+    {
+        $resolvedColumns = (new ColumnAttributesResolver())->resolve($sheet);
+        if ([] === $resolvedColumns) {
+            return '';
+        }
+
+        $xml = '<cols>';
+        foreach ($resolvedColumns as $column) {
+            $xml .= '<col min="'.$column->start.'" max="'.$column->end.'"';
+            if (null !== $column->width) {
+                $xml .= ' width="'.$column->width.'" customWidth="true"';
+            }
+            if (true === $column->hidden) {
+                $xml .= ' hidden="true"';
+            }
+            if (true === $column->collapsed) {
+                $xml .= ' collapsed="true"';
+            }
+            if (null !== $column->outlineLevel && $column->outlineLevel > 0) {
+                $xml .= ' outlineLevel="'.$column->outlineLevel.'"';
+            }
+            $xml .= '/>';
         }
         $xml .= '</cols>';
 

--- a/tests/Writer/Common/Entity/SheetTest.php
+++ b/tests/Writer/Common/Entity/SheetTest.php
@@ -102,6 +102,41 @@ final class SheetTest extends TestCase
         $this->expectNotToPerformAssertions();
     }
 
+    public function testSetColumnHiddenGathersConsecutiveColumnsIntoRanges(): void
+    {
+        $sheet = $this->createSheet(0, 'workbookId1');
+        $sheet->setColumnHidden(true, 1, 2, 4);
+
+        $hiddens = $sheet->getColumnHiddens();
+        self::assertCount(2, $hiddens);
+        self::assertSame([1, 2, true], [$hiddens[0]->start, $hiddens[0]->end, $hiddens[0]->hidden]);
+        self::assertSame([4, 4, true], [$hiddens[1]->start, $hiddens[1]->end, $hiddens[1]->hidden]);
+    }
+
+    public function testSetColumnCollapsedForRangeAppendsEntry(): void
+    {
+        $sheet = $this->createSheet(0, 'workbookId1');
+        $sheet->setColumnCollapsedForRange(true, 2, 5);
+
+        $collapseds = $sheet->getColumnCollapseds();
+        self::assertCount(1, $collapseds);
+        self::assertSame(2, $collapseds[0]->start);
+        self::assertSame(5, $collapseds[0]->end);
+        self::assertTrue($collapseds[0]->collapsed);
+    }
+
+    public function testSetColumnOutlineLevelAppendsEntry(): void
+    {
+        $sheet = $this->createSheet(0, 'workbookId1');
+        $sheet->setColumnOutlineLevel(3, 1);
+
+        $levels = $sheet->getColumnOutlineLevels();
+        self::assertCount(1, $levels);
+        self::assertSame(1, $levels[0]->start);
+        self::assertSame(1, $levels[0]->end);
+        self::assertSame(3, $levels[0]->level);
+    }
+
     /**
      * @param 0|positive-int $sheetIndex
      */

--- a/tests/Writer/Common/Entity/SheetTest.php
+++ b/tests/Writer/Common/Entity/SheetTest.php
@@ -113,6 +113,18 @@ final class SheetTest extends TestCase
         self::assertSame([4, 4, true], [$hiddens[1]->start, $hiddens[1]->end, $hiddens[1]->hidden]);
     }
 
+    public function testSetColumnHiddenForRangeAppendsEntry(): void
+    {
+        $sheet = $this->createSheet(0, 'workbookId1');
+        $sheet->setColumnHiddenForRange(true, 2, 5);
+
+        $hiddens = $sheet->getColumnHiddens();
+        self::assertCount(1, $hiddens);
+        self::assertSame(2, $hiddens[0]->start);
+        self::assertSame(5, $hiddens[0]->end);
+        self::assertTrue($hiddens[0]->hidden);
+    }
+
     public function testSetColumnCollapsedForRangeAppendsEntry(): void
     {
         $sheet = $this->createSheet(0, 'workbookId1');
@@ -134,6 +146,18 @@ final class SheetTest extends TestCase
         self::assertCount(1, $levels);
         self::assertSame(1, $levels[0]->start);
         self::assertSame(1, $levels[0]->end);
+        self::assertSame(3, $levels[0]->level);
+    }
+
+    public function testSetColumnOutlineLevelForRangeAppendsEntry(): void
+    {
+        $sheet = $this->createSheet(0, 'workbookId1');
+        $sheet->setColumnOutlineLevelForRange(3, 2, 5);
+
+        $levels = $sheet->getColumnOutlineLevels();
+        self::assertCount(1, $levels);
+        self::assertSame(2, $levels[0]->start);
+        self::assertSame(5, $levels[0]->end);
         self::assertSame(3, $levels[0]->level);
     }
 

--- a/tests/Writer/ODS/SheetTest.php
+++ b/tests/Writer/ODS/SheetTest.php
@@ -124,6 +124,28 @@ final class SheetTest extends TestCase
         self::assertStringContainsString('table:number-columns-repeated="2"', $xmlContents, 'No expected column width definition found in sheet');
     }
 
+    public function testWritesHiddenAndCollapsedColumnsAsCollapsedVisibility(): void
+    {
+        $fileName = 'test_column_hidden_collapsed.ods';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+
+        $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+        $writer->addRow(Row::fromValues(['ods--11', 'ods--12', 'ods--13']));
+        $sheet = $writer->getCurrentSheet();
+        $sheet->setColumnHidden(true, 1);
+        $sheet->setColumnCollapsed(true, 3);
+        $writer->close();
+
+        $pathToWorkbookFile = $resourcePath.'#content.xml';
+        $xmlContents = file_get_contents('zip://'.$pathToWorkbookFile);
+
+        self::assertNotFalse($xmlContents);
+        self::assertStringContainsString('table:visibility="collapse"', $xmlContents, 'Hidden/collapsed columns should be written with collapse visibility');
+        self::assertStringContainsString('<table:table-column table:default-cell-style-name="ce1" table:style-name="default-column-style" table:visibility="collapse" table:number-columns-repeated="1"/>', $xmlContents, 'No expected collapsed column definition found in sheet');
+    }
+
     /**
      * @param array<array-key, array{start: positive-int, end: positive-int, width: float}> $rules
      * @param array<array-key, array{repeated: string, style: string, width?: string}>      $expected

--- a/tests/Writer/XLSX/SheetTest.php
+++ b/tests/Writer/XLSX/SheetTest.php
@@ -354,6 +354,53 @@ final class SheetTest extends TestCase
         self::assertStringContainsString('<col min="1" max="3" width="100" customWidth="true"', $xmlContents, 'No expected column width definition found in sheet');
     }
 
+    public function testWritesHiddenCollapsedAndOutlineLevelColumnsToSheet(): void
+    {
+        $fileName = 'test_column_hidden_collapsed_outline.xlsx';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+
+        $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+        $writer->addRow(Row::fromValues(['a', 'b', 'c', 'd', 'e', 'f']));
+        $sheet = $writer->getCurrentSheet();
+        $sheet->setColumnHidden(true, 1);
+        $sheet->setColumnCollapsed(true, 2);
+        $sheet->setColumnOutlineLevel(2, 3);
+        $sheet->setColumnWidth(42.0, 5, 6);
+        $sheet->setColumnHidden(true, 5, 6);
+        $writer->close();
+
+        $pathToWorkbookFile = $resourcePath.'#xl/worksheets/sheet1.xml';
+        $xmlContents = file_get_contents('zip://'.$pathToWorkbookFile);
+
+        self::assertNotFalse($xmlContents);
+        self::assertStringContainsString('<col min="1" max="1" hidden="true"/>', $xmlContents, 'No hidden column definition found in sheet');
+        self::assertStringContainsString('<col min="2" max="2" collapsed="true"/>', $xmlContents, 'No collapsed column definition found in sheet');
+        self::assertStringContainsString('<col min="3" max="3" outlineLevel="2"/>', $xmlContents, 'No outline-level column definition found in sheet');
+        self::assertStringContainsString('<col min="5" max="6" width="42" customWidth="true" hidden="true"/>', $xmlContents, 'Width and hidden attributes should be combined into a single coalesced column');
+    }
+
+    public function testCoalescesAdjacentHiddenColumnsIntoASingleRange(): void
+    {
+        $fileName = 'test_column_hidden_coalesced.xlsx';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+
+        $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+        $writer->addRow(Row::fromValues(['a', 'b', 'c']));
+        $sheet = $writer->getCurrentSheet();
+        $sheet->setColumnHidden(true, 1, 2, 3);
+        $writer->close();
+
+        $pathToWorkbookFile = $resourcePath.'#xl/worksheets/sheet1.xml';
+        $xmlContents = file_get_contents('zip://'.$pathToWorkbookFile);
+
+        self::assertNotFalse($xmlContents);
+        self::assertStringContainsString('<col min="1" max="3" hidden="true"/>', $xmlContents, 'Adjacent hidden columns should coalesce into a single range');
+    }
+
     public function testCanWriteAFormula(): void
     {
         $fileName = 'test_formula.xlsx';


### PR DESCRIPTION
## Summary

Adds support for **hidden**, **collapsed**, and **outline-level** columns to the XLSX and ODS writers, following the design discussed by the maintainer in https://github.com/openspout/openspout/pull/275#issuecomment-2513861027.

Each `<col>` attribute is modeled as an independent, `readonly` value object and is exposed on the `Sheet` **API only** (not `Options`), per the maintainer's guidance. At write time a new `ColumnAttributesResolver` coalesces widths + visibility attributes into the minimal set of `<col>` ranges.

### New `Sheet` API

- `setColumnHidden(bool $hidden, int ...$columns)` / `setColumnHiddenForRange(bool $hidden, int $start, int $end)` / `getColumnHiddens()`
- `setColumnCollapsed(bool $collapsed, int ...$columns)` / `setColumnCollapsedForRange(bool $collapsed, int $start, int $end)` / `getColumnCollapseds()`
- `setColumnOutlineLevel(int $level, int ...$columns)` / `setColumnOutlineLevelForRange(int $level, int $start, int $end)` / `getColumnOutlineLevels()`

### Output

- **XLSX**: `hidden="true"`, `collapsed="true"`, `outlineLevel="N"` on coalesced `<col>` ranges.
- **ODS**: hidden/collapsed columns written as `table:visibility="collapse"`.
- **ODS outline-level grouping is intentionally deferred** (documented as a known limitation).

## Tests

- XLSX writer tests for the three attributes + width/hidden coalescing + adjacent-range merging.
- ODS writer test asserting `table:visibility="collapse"`.
- `Sheet` entity getter tests (range gathering, `…ForRange`, outline level).

 