### PR TITLE
Fix: truncated comments.xml and vmlDrawing.vml on suspended sheets

### DIFF
--- a/src/Writer/XLSX/Manager/CommentsManager.php
+++ b/src/Writer/XLSX/Manager/CommentsManager.php
@@ -105,8 +105,10 @@ final class CommentsManager
     {
         $sheetId = $sheet->getId();
 
+        // suspended sheets (closeTempCommentFiles) have no active pointer
+        // but file on disk still needs footer. reopen in append mode, write footer, close.
         if (!isset($this->commentsFilePointers[$sheetId])) {
-            return;
+            $this->reopenTempCommentFiles($sheet);
         }
 
         $commentFp = $this->commentsFilePointers[$sheetId];
@@ -146,6 +148,11 @@ final class CommentsManager
     public function reopenTempCommentFiles(Worksheet $sheet): void
     {
         $sheetId = $sheet->getId();
+
+        // already open, avoid leaking existing handles
+        if (isset($this->commentsFilePointers[$sheetId])) {
+            return;
+        }
 
         $commentFp = fopen($this->getCommentsFilePath($sheet), 'a');
         \assert(false !== $commentFp);

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -1746,4 +1746,70 @@ final class WriterTest extends TestCase
             'Expected all XML/VML parts well-formed, malformed: '.implode(', ', $malformed)
         );
     }
+
+    /**
+     * Regression: switching between sheets back and forth must keep all XML parts well-formed.
+     *
+     * @see https://github.com/openspout/openspout/issues/401
+     */
+    public function testSwitchBetweenSheetsKeepsXmlWellFormed(): void
+    {
+        $fileName = 'test_switch_sheets_xml_wellformed.xlsx';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+
+        $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+
+        $sheet1 = $writer->getCurrentSheet();
+        $sheet1->setName('First');
+        $writer->addRow(Row::fromValues(['sheet1-a']));
+
+        $writer->addNewSheetAndMakeItCurrent()->setName('Second');
+        $writer->addRow(Row::fromValues(['sheet2-a']));
+
+        // switch back to sheet 1, resume then suspend again
+        $writer->setCurrentSheet($sheet1);
+        $writer->addRow(Row::fromValues(['sheet1-b']));
+
+        // switch to sheet 2, resume then suspend again
+        $sheet2 = $writer->getSheets()[1];
+        $writer->setCurrentSheet($sheet2);
+        $writer->addRow(Row::fromValues(['sheet2-b']));
+
+        $writer->close();
+
+        // sheet2 was current at close -> sheet1 suspended, sheet2 normal
+        // sheet1 was suspended twice (once at first switch, once again at second switch)
+        // sheet2 was suspended once (when switching back to sheet1)
+
+        $zip = new ZipArchive();
+        $openResult = $zip->open($resourcePath);
+        self::assertTrue($openResult);
+
+        libxml_use_internal_errors(true);
+        $malformed = [];
+
+        for ($i = 0; $i < $zip->numFiles; ++$i) {
+            $name = $zip->getNameIndex($i);
+            if (!\is_string($name) || !str_ends_with($name, '.xml') && !str_ends_with($name, '.vml')) {
+                continue;
+            }
+
+            $content = $zip->getFromName($name);
+            self::assertNotFalse($content);
+
+            if (false === simplexml_load_string($content)) {
+                $malformed[] = $name;
+            }
+        }
+
+        $zip->close();
+        libxml_use_internal_errors(false);
+
+        self::assertEmpty(
+            $malformed,
+            'Expected all XML/VML parts well-formed after switching sheets back and forth, malformed: '.implode(', ', $malformed)
+        );
+    }
 }

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -1690,4 +1690,60 @@ final class WriterTest extends TestCase
 
         return $xmlReader;
     }
+
+    /**
+     * Regression: multi-sheet XLSX must not produce truncated XML in comments or vmlDrawing files.
+     *
+     * @see https://github.com/openspout/openspout/issues/401
+     */
+    public function testMultiSheetXmlFilesAreWellFormed(): void
+    {
+        $fileName = 'test_multisheet_xml_wellformed.xlsx';
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+
+        $options = new Options(tempFolder: (new TestUsingResource())->getTempFolderPath());
+        $writer = new Writer($options);
+        $writer->openToFile($resourcePath);
+
+        // 3 sheets, only last one active at close — forces suspend on sheets 1 & 2
+        $writer->getCurrentSheet()->setName('First');
+        $writer->addRow(Row::fromValues(['hello']));
+
+        $writer->addNewSheetAndMakeItCurrent()->setName('Second');
+        $writer->addRow(Row::fromValues(['world']));
+
+        $writer->addNewSheetAndMakeItCurrent()->setName('Third');
+        $writer->addRow(Row::fromValues(['foo']));
+
+        $writer->close();
+
+        $zip = new ZipArchive();
+        $openResult = $zip->open($resourcePath);
+        self::assertTrue($openResult);
+
+        libxml_use_internal_errors(true);
+        $malformed = [];
+
+        for ($i = 0; $i < $zip->numFiles; ++$i) {
+            $name = $zip->getNameIndex($i);
+            if (!\is_string($name) || !str_ends_with($name, '.xml') && !str_ends_with($name, '.vml')) {
+                continue;
+            }
+
+            $content = $zip->getFromName($name);
+            self::assertNotFalse($content);
+
+            if (false === simplexml_load_string($content)) {
+                $malformed[] = $name;
+            }
+        }
+
+        $zip->close();
+        libxml_use_internal_errors(false);
+
+        self::assertEmpty(
+            $malformed,
+            'Expected all XML/VML parts well-formed, malformed: '.implode(', ', $malformed)
+        );
+    }
 }

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -1582,116 +1582,6 @@ final class WriterTest extends TestCase
     }
 
     /**
-     * @param Row[] $allRows
-     */
-    private function writeToXLSXFile(
-        array $allRows,
-        string $fileName,
-        ?bool $shouldUseInlineStrings = null,
-        ?bool $shouldCreateSheetsAutomatically = null
-    ): Writer {
-        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
-
-        $options = ['tempFolder' => (new TestUsingResource())->getTempFolderPath()];
-        if (null !== $shouldUseInlineStrings) {
-            $options['SHOULD_USE_INLINE_STRINGS'] = $shouldUseInlineStrings;
-        }
-        if (null !== $shouldCreateSheetsAutomatically) {
-            $options['SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY'] = $shouldCreateSheetsAutomatically;
-        }
-        $writer = new Writer(new Options(...$options));
-
-        $writer->openToFile($resourcePath);
-        $writer->addRows($allRows);
-        $writer->close();
-
-        return $writer;
-    }
-
-    /**
-     * @param Row[] $allRows
-     */
-    private function writeToMultipleSheetsInXLSXFile(
-        array $allRows,
-        int $numSheets,
-        string $fileName,
-        ?bool $shouldUseInlineStrings = null,
-        ?bool $shouldCreateSheetsAutomatically = null
-    ): Writer {
-        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
-
-        $options = ['tempFolder' => (new TestUsingResource())->getTempFolderPath()];
-        if (null !== $shouldUseInlineStrings) {
-            $options['SHOULD_USE_INLINE_STRINGS'] = $shouldUseInlineStrings;
-        }
-        if (null !== $shouldCreateSheetsAutomatically) {
-            $options['SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY'] = $shouldCreateSheetsAutomatically;
-        }
-        $writer = new Writer(new Options(...$options));
-
-        $writer->openToFile($resourcePath);
-        $writer->addRows($allRows);
-
-        for ($i = 1; $i < $numSheets; ++$i) {
-            $writer->addNewSheetAndMakeItCurrent();
-            $writer->addRows($allRows);
-        }
-
-        $writer->close();
-
-        return $writer;
-    }
-
-    /**
-     * @param mixed $inlineData
-     */
-    private function assertInlineDataWasWrittenToSheet(string $fileName, int $sheetIndex, $inlineData, string $message = ''): void
-    {
-        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
-        $pathToSheetFile = $resourcePath.'#xl/worksheets/sheet'.$sheetIndex.'.xml';
-        $xmlContents = file_get_contents('zip://'.$pathToSheetFile);
-
-        self::assertNotFalse($xmlContents);
-        self::assertStringContainsString((string) $inlineData, $xmlContents, $message);
-    }
-
-    /**
-     * @param mixed $inlineData
-     */
-    private function assertInlineDataWasNotWrittenToSheet(string $fileName, int $sheetIndex, $inlineData, string $message = ''): void
-    {
-        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
-        $pathToSheetFile = $resourcePath.'#xl/worksheets/sheet'.$sheetIndex.'.xml';
-        $xmlContents = file_get_contents('zip://'.$pathToSheetFile);
-
-        self::assertNotFalse($xmlContents);
-        self::assertStringNotContainsString((string) $inlineData, $xmlContents, $message);
-    }
-
-    private function assertSharedStringWasWritten(string $fileName, string $sharedString, string $message = ''): void
-    {
-        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
-        $pathToSharedStringsFile = $resourcePath.'#xl/sharedStrings.xml';
-        $xmlContents = file_get_contents('zip://'.$pathToSharedStringsFile);
-
-        self::assertNotFalse($xmlContents);
-        self::assertStringContainsString($sharedString, $xmlContents, $message);
-    }
-
-    /**
-     * @param string $sheetIndex - 1 based
-     */
-    private function getXmlReaderForSheetFromXmlFile(string $fileName, string $sheetIndex): XMLReader
-    {
-        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
-
-        $xmlReader = new XMLReader();
-        $xmlReader->openFileInZip($resourcePath, 'xl/worksheets/sheet'.$sheetIndex.'.xml');
-
-        return $xmlReader;
-    }
-
-    /**
      * Regression: multi-sheet XLSX must not produce truncated XML in comments or vmlDrawing files.
      *
      * @see https://github.com/openspout/openspout/issues/401
@@ -1811,5 +1701,115 @@ final class WriterTest extends TestCase
             $malformed,
             'Expected all XML/VML parts well-formed after switching sheets back and forth, malformed: '.implode(', ', $malformed)
         );
+    }
+
+    /**
+     * @param Row[] $allRows
+     */
+    private function writeToXLSXFile(
+        array $allRows,
+        string $fileName,
+        ?bool $shouldUseInlineStrings = null,
+        ?bool $shouldCreateSheetsAutomatically = null
+    ): Writer {
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+
+        $options = ['tempFolder' => (new TestUsingResource())->getTempFolderPath()];
+        if (null !== $shouldUseInlineStrings) {
+            $options['SHOULD_USE_INLINE_STRINGS'] = $shouldUseInlineStrings;
+        }
+        if (null !== $shouldCreateSheetsAutomatically) {
+            $options['SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY'] = $shouldCreateSheetsAutomatically;
+        }
+        $writer = new Writer(new Options(...$options));
+
+        $writer->openToFile($resourcePath);
+        $writer->addRows($allRows);
+        $writer->close();
+
+        return $writer;
+    }
+
+    /**
+     * @param Row[] $allRows
+     */
+    private function writeToMultipleSheetsInXLSXFile(
+        array $allRows,
+        int $numSheets,
+        string $fileName,
+        ?bool $shouldUseInlineStrings = null,
+        ?bool $shouldCreateSheetsAutomatically = null
+    ): Writer {
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+
+        $options = ['tempFolder' => (new TestUsingResource())->getTempFolderPath()];
+        if (null !== $shouldUseInlineStrings) {
+            $options['SHOULD_USE_INLINE_STRINGS'] = $shouldUseInlineStrings;
+        }
+        if (null !== $shouldCreateSheetsAutomatically) {
+            $options['SHOULD_CREATE_NEW_SHEETS_AUTOMATICALLY'] = $shouldCreateSheetsAutomatically;
+        }
+        $writer = new Writer(new Options(...$options));
+
+        $writer->openToFile($resourcePath);
+        $writer->addRows($allRows);
+
+        for ($i = 1; $i < $numSheets; ++$i) {
+            $writer->addNewSheetAndMakeItCurrent();
+            $writer->addRows($allRows);
+        }
+
+        $writer->close();
+
+        return $writer;
+    }
+
+    /**
+     * @param mixed $inlineData
+     */
+    private function assertInlineDataWasWrittenToSheet(string $fileName, int $sheetIndex, $inlineData, string $message = ''): void
+    {
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+        $pathToSheetFile = $resourcePath.'#xl/worksheets/sheet'.$sheetIndex.'.xml';
+        $xmlContents = file_get_contents('zip://'.$pathToSheetFile);
+
+        self::assertNotFalse($xmlContents);
+        self::assertStringContainsString((string) $inlineData, $xmlContents, $message);
+    }
+
+    /**
+     * @param mixed $inlineData
+     */
+    private function assertInlineDataWasNotWrittenToSheet(string $fileName, int $sheetIndex, $inlineData, string $message = ''): void
+    {
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+        $pathToSheetFile = $resourcePath.'#xl/worksheets/sheet'.$sheetIndex.'.xml';
+        $xmlContents = file_get_contents('zip://'.$pathToSheetFile);
+
+        self::assertNotFalse($xmlContents);
+        self::assertStringNotContainsString((string) $inlineData, $xmlContents, $message);
+    }
+
+    private function assertSharedStringWasWritten(string $fileName, string $sharedString, string $message = ''): void
+    {
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+        $pathToSharedStringsFile = $resourcePath.'#xl/sharedStrings.xml';
+        $xmlContents = file_get_contents('zip://'.$pathToSharedStringsFile);
+
+        self::assertNotFalse($xmlContents);
+        self::assertStringContainsString($sharedString, $xmlContents, $message);
+    }
+
+    /**
+     * @param string $sheetIndex - 1 based
+     */
+    private function getXmlReaderForSheetFromXmlFile(string $fileName, string $sheetIndex): XMLReader
+    {
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+
+        $xmlReader = new XMLReader();
+        $xmlReader->openFileInZip($resourcePath, 'xl/worksheets/sheet'.$sheetIndex.'.xml');
+
+        return $xmlReader;
     }
 }


### PR DESCRIPTION
## Multi-sheet XLSX files are written with a truncated `comments*.xml` and `vmlDrawing*.vml`

**Affects:** 5.x (since v5.10.1) · **Closes:** #401

### Problem
Introduced by #395, `suspendSheet()` calls `closeTempCommentFiles()` which closes and unsets file pointers **without writing XML footers** (`</commentList></comments>` and `</xml>`). At close time, `closeWorksheetCommentFiles()` sees the pointers unset and returns early-leaving `commentsN.xml` and `vmlDrawingN.vml` truncated for every sheet that is not the current one when `close()` is called.

Any XLSX with 2+ sheets is affected, even without comments.

### Fix
**`CommentsManager::closeWorksheetCommentFiles`** instead of returning early when pointers are unset, reopen the temp files in append mode via `reopenTempCommentFiles()`, then write footers and close normally.

**`CommentsManager::reopenTempCommentFiles`** add `isset` guard to prevent FD leak when `resumeSheet()` is called on a freshly created sheet (pointers already open from `createWorksheetCommentFiles`).

### Tests added
- `testMultiSheetXmlFilesAreWellFormed` 3 sheets, close, validate all XML/VML parts via `simplexml_load_string`
- `testSwitchBetweenSheetsKeepsXmlWellFormed` Sheet1 -> Sheet2 -> Sheet1 -> Sheet2, close, validate all parts well-formed
- All 193 existing XLSX writer tests continue to pass