### PR TITLE
Fix XLSX freeze pane for row/column-only freezes

### DIFF
--- a/src/Writer/XLSX/Entity/SheetView.php
+++ b/src/Writer/XLSX/Entity/SheetView.php
@@ -225,14 +225,26 @@ final readonly class SheetView implements SheetViewInterface
         }
 
         $columnIndex = CellHelper::getColumnIndexFromCellIndex($this->freezeColumn.'1');
+        // A freeze row of 0 or 1 means no rows are frozen, so the visible cell must be in row 1.
+        $freezeRow = max(1, $this->freezeRow);
 
-        return '<pane'.$this->generateAttributes([
-            'xSplit' => $columnIndex,
-            'ySplit' => $this->freezeRow - 1,
-            'topLeftCell' => $this->freezeColumn.$this->freezeRow,
-            'activePane' => 'bottomRight',
-            'state' => 'frozen',
-        ]).'/>';
+        $attributes = [];
+        if ($columnIndex > 0) {
+            $attributes['xSplit'] = $columnIndex;
+        }
+        if ($freezeRow > 1) {
+            $attributes['ySplit'] = $freezeRow - 1;
+        }
+
+        $attributes['topLeftCell'] = $this->freezeColumn.$freezeRow;
+        $attributes['activePane'] = match (true) {
+            $columnIndex > 0 && $freezeRow > 1 => 'bottomRight',
+            $columnIndex > 0 => 'topRight',
+            default => 'bottomLeft',
+        };
+        $attributes['state'] = 'frozen';
+
+        return '<pane'.$this->generateAttributes($attributes).'/>';
     }
 
     /**

--- a/tests/Reader/XLSX/Entity/SheetViewTest.php
+++ b/tests/Reader/XLSX/Entity/SheetViewTest.php
@@ -28,6 +28,7 @@ final class SheetViewTest extends TestCase
         );
 
         self::assertStringContainsString('<pane', $sheetView->getXml());
+        self::assertStringContainsString('activePane="bottomRight"', $sheetView->getXml());
 
         $sheetView = new SheetView(
             freezeRow: 1,
@@ -35,5 +36,30 @@ final class SheetViewTest extends TestCase
         );
 
         self::assertStringNotContainsString('<pane', $sheetView->getXml());
+    }
+
+    public function testFreezingOnlyAColumnShouldGenerateValidPaneMetadata(): void
+    {
+        $sheetView = (new SheetView())->withFreezeColumn('B');
+
+        $xml = $sheetView->getXml();
+
+        self::assertStringContainsString('<pane', $xml);
+        self::assertStringNotContainsString('ySplit', $xml);
+        self::assertStringContainsString('topLeftCell="B1"', $xml);
+        self::assertStringContainsString('activePane="topRight"', $xml);
+    }
+
+    public function testFreezingOnlyARowShouldGenerateValidPaneMetadata(): void
+    {
+        $sheetView = (new SheetView())->withFreezeRow(2);
+
+        $xml = $sheetView->getXml();
+
+        self::assertStringContainsString('<pane', $xml);
+        self::assertStringNotContainsString('xSplit', $xml);
+        self::assertStringContainsString('ySplit="1"', $xml);
+        self::assertStringContainsString('topLeftCell="A2"', $xml);
+        self::assertStringContainsString('activePane="bottomLeft"', $xml);
     }
 }


### PR DESCRIPTION
### Summary
`SheetView` generates invalid `<pane>` metadata when freezing on a single axis. This was originally reported in #375: using `withFreezeColumn('B')` emitted `ySplit="-1"` and `topLeftCell="B0"`, which Excel repairs on open.

The same class of bug also affected row-only and multi-axis freezes, along with an incorrect `activePane`.

### Problem
`SheetView::getFreezeCellPaneXml()` unconditionally emitted both splits:

```php
'ySplit' => $this->freezeRow - 1,
'topLeftCell' => $this->freezeColumn.$this->freezeRow,
'activePane' => 'bottomRight',
```

This produced:
- `ySplit="-1"` / `topLeftCell="B0"` for column-only freezes (`freezeRow` 0 or 1)
- a redundant `xSplit="0"` for row-only freezes
- `activePane="bottomRight"` even for single-axis freezes (should be `topRight`/`bottomLeft`)

### Fix
Only emit a split attribute when that axis is actually frozen, clamp the visible cell to a valid row, and select `activePane` from the frozen axes:

| Scenario | Pane |
|---|---|
| Column-only | `<pane xSplit="1" topLeftCell="B1" activePane="topRight" state="frozen"/>` |
| Row-only (first row) | `<pane ySplit="1" topLeftCell="A2" activePane="bottomLeft" state="frozen"/>` |
| Both | `<pane xSplit="1" ySplit="1" topLeftCell="B2" activePane="bottomRight" state="frozen"/>` |

### Tests
Added regression tests for column-only and row-only freezing (valid splits, `topLeftCell`, and `activePane`), and extended the existing pane test. The row-only test freezes the first row.
