### PR TITLE
fix: Polish XLSX freeze pane tests (follow-up to #409)

### DIFF
--- a/tests/Reader/XLSX/Entity/SheetViewTest.php
+++ b/tests/Reader/XLSX/Entity/SheetViewTest.php
@@ -27,8 +27,9 @@ final class SheetViewTest extends TestCase
             freezeColumn: 'B',
         );
 
-        self::assertStringContainsString('<pane', $sheetView->getXml());
-        self::assertStringContainsString('activePane="bottomRight"', $sheetView->getXml());
+        $xml = $sheetView->getXml();
+        self::assertStringContainsString('<pane', $xml);
+        self::assertStringContainsString('activePane="bottomRight"', $xml);
 
         $sheetView = new SheetView(
             freezeRow: 1,
@@ -45,6 +46,7 @@ final class SheetViewTest extends TestCase
         $xml = $sheetView->getXml();
 
         self::assertStringContainsString('<pane', $xml);
+        self::assertStringContainsString('xSplit="1"', $xml);
         self::assertStringNotContainsString('ySplit', $xml);
         self::assertStringContainsString('topLeftCell="B1"', $xml);
         self::assertStringContainsString('activePane="topRight"', $xml);


### PR DESCRIPTION
Follow-up to #409 refining the XLSX freeze pane tests:

- add the missing positive assertion that column-only freezing emits `xSplit="1"`
- cache `SheetView::getXml()` in a variable instead of calling it repeatedly
