### PR TITLE
fix: write apostrophes in XLSX sheet names unescaped (and enforce reserved "History" name)

### DIFF
--- a/src/Common/Helper/Escaper/XLSX.php
+++ b/src/Common/Helper/Escaper/XLSX.php
@@ -101,9 +101,15 @@ final readonly class XLSX implements EscaperInterface
     {
         $escapedString = $this->escapeControlCharacters($string);
 
-        // @NOTE: Using ENT_QUOTES as XML entities ('<', '>', '&') as well as
-        //        single/double quotes (for XML attributes) need to be encoded.
-        return htmlspecialchars($escapedString, ENT_QUOTES, 'UTF-8');
+        // @NOTE: Using ENT_COMPAT to encode '<', '>', '&' as well as double
+        //        quotes (needed because this writer emits XML attribute values
+        //        that are double-quoted). An apostrophe does not need escaping
+        //        inside a double-quoted attribute (or in text content), and
+        //        Microsoft Excel writes it literally in sheet names while it
+        //        must repair files where the apostrophe is entity-encoded
+        //        as `&#039;` (see OpenSpout issue #299). Other writers that emit
+        //        single-quoted attribute values would need to escape it.
+        return htmlspecialchars($escapedString, ENT_COMPAT, 'UTF-8');
     }
 
     /**

--- a/src/Writer/Common/Entity/Sheet.php
+++ b/src/Writer/Common/Entity/Sheet.php
@@ -107,6 +107,8 @@ final class Sheet
      *  - it should not be blank
      *  - it should not exceed 31 characters
      *  - it should not contain these characters: \ / ? * : [ or ]
+     *  - it should not start or end with a single quote (apostrophe)
+     *  - it should not be named "History" (reserved by Excel)
      *  - it should be unique.
      *
      * @param string $name Name of the sheet

--- a/src/Writer/Common/Manager/SheetManager.php
+++ b/src/Writer/Common/Manager/SheetManager.php
@@ -66,6 +66,10 @@ final class SheetManager
             if ($this->doesStartOrEndWithSingleQuote($name)) {
                 $failedRequirements[] = 'It should not start or end with a single quote';
             }
+
+            if ($this->isReservedSheetName($name)) {
+                $failedRequirements[] = 'It should not be a reserved name ("History")';
+            }
         }
 
         if (0 !== \count($failedRequirements)) {
@@ -112,6 +116,17 @@ final class SheetManager
         $endsWithSingleQuote = ($this->stringHelper->getCharLastOccurrencePosition('\'', $name) === ($this->stringHelper->getStringLength($name) - 1));
 
         return $startsWithSingleQuote || $endsWithSingleQuote;
+    }
+
+    /**
+     * Returns whether the given name is one of the names that are reserved
+     * by Excel and therefore cannot be used for a worksheet.
+     *
+     * @return bool TRUE if the name is reserved, FALSE otherwise
+     */
+    private function isReservedSheetName(string $name): bool
+    {
+        return 0 === strcasecmp($name, 'History');
     }
 
     /**

--- a/tests/Common/Helper/Escaper/XLSXTest.php
+++ b/tests/Common/Helper/Escaper/XLSXTest.php
@@ -25,7 +25,7 @@ final class XLSXTest extends TestCase
     {
         return [
             ['test', 'test'],
-            ['adam\'s "car"', 'adam&#039;s &quot;car&quot;'],
+            ['adam\'s "car"', 'adam\'s &quot;car&quot;'],
             ["\n", "\n"],
             ["\r", "\r"],
             ["\t", "\t"],
@@ -34,7 +34,7 @@ final class XLSXTest extends TestCase
             ['_x0000_', '_x005F_x0000_'],
             [\chr(21), '_x0015_'],
             ['control '.\chr(21).' character', 'control _x0015_ character'],
-            ['control\'s '.\chr(21).' "character"', 'control&#039;s _x0015_ &quot;character&quot;'],
+            ['control\'s '.\chr(21).' "character"', 'control\'s _x0015_ &quot;character&quot;'],
         ];
     }
 

--- a/tests/Writer/Common/Entity/SheetTest.php
+++ b/tests/Writer/Common/Entity/SheetTest.php
@@ -62,6 +62,9 @@ final class SheetTest extends TestCase
             ['Illegal ]'],
             ['\'Illegal start'],
             ['Illegal end\''],
+            ['History'],
+            ['HISTORY'],
+            ['history'],
         ];
     }
 

--- a/tests/Writer/XLSX/SheetTest.php
+++ b/tests/Writer/XLSX/SheetTest.php
@@ -44,6 +44,25 @@ final class SheetTest extends TestCase
         $this->assertSheetNameEquals($customSheetName, $fileName, "The sheet name should have been changed to '{$customSheetName}'");
     }
 
+    public function testSheetNameWithApostropheIsWrittenUnaltered(): void
+    {
+        $fileName = 'test_set_name_with_apostrophe.xlsx';
+        $sheetName = "asdf'ass";
+
+        $this->writeDataToSheetWithCustomName($fileName, $sheetName);
+
+        $resourcePath = (new TestUsingResource())->getGeneratedResourcePath($fileName);
+        $pathToWorkbookFile = $resourcePath.'#xl/workbook.xml';
+        $xmlContents = file_get_contents('zip://'.$pathToWorkbookFile);
+
+        self::assertNotFalse($xmlContents);
+
+        self::assertStringContainsString("<sheet name=\"{$sheetName}\"", $xmlContents, 'A sheet name containing an apostrophe should be written unaltered');
+        self::assertStringNotContainsString('&#039;', $xmlContents, 'The apostrophe in a sheet name should not be entity-encoded');
+        self::assertStringNotContainsString('&apos;', $xmlContents, 'The apostrophe in a sheet name should not use the &apos; form');
+        self::assertStringNotContainsString('&amp;#039;', $xmlContents, 'The apostrophe in a sheet name should not be double-escaped');
+    }
+
     public function testSetSheetNameShouldThrowWhenNameIsAlreadyUsed(): void
     {
         $this->expectException(InvalidSheetNameException::class);

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -508,7 +508,7 @@ final class WriterTest extends TestCase
 
         $this->writeToXLSXFile($dataRows, $fileName);
 
-        $this->assertInlineDataWasWrittenToSheet($fileName, 1, 'I&#039;m in &quot;great&quot; mood', 'Quotes should be escaped');
+        $this->assertInlineDataWasWrittenToSheet($fileName, 1, 'I\'m in &quot;great&quot; mood', 'Apostrophes and double quotes in text content');
         $this->assertInlineDataWasWrittenToSheet($fileName, 1, 'This &lt;must&gt; be escaped &amp; tested', '<, > and & should be escaped');
     }
 


### PR DESCRIPTION
Fixes #299: XLSX sheet names containing an apostrophe (`'`) are entity-encoded by the XLSX escaper as `&#039;` in `xl/workbook.xml`. Microsoft Excel writes such names with a literal apostrophe and must repair files where it is encoded, prompting "We found a problem with some content...". This change switches the escaper from `ENT_QUOTES` to `ENT_COMPAT` so the apostrophe is no longer encoded, matching Excel's own output. `<`, `>`, `&` and `"` are still escaped, so the XML remains well-formed.

Sheet-name handling now tracks the restrictions documented by Microsoft in ["Rename a worksheet"](https://support.microsoft.com/en-us/excel/rename-a-worksheet):

- the apostrophe is legal in the middle of a name, but names cannot **begin or end** with one,
- names cannot be blank,
- names cannot exceed 31 characters,
- names cannot contain `\ / ? * : [ ]`,
- names cannot use the reserved word "History".

The reserved "History" name is now rejected (case-insensitively), and the start/end-with-apostrophe restriction is now documented on `Sheet::setName()`, bringing the implementation in line with the docs.

### Tests

- Add integration reproduction test: an apostrophe sheet name is written unaltered (and never as `&#039;`).
- Update the XLSX escaper and writer text-content expectations accordingly.
- Add "History" invalid-name data-provider cases (`History`, `HISTORY`, `history`).
