### PR TITLE
fix: keep auto-height rows auto-fitted in XLSX (customHeight absent)

### DIFF
--- a/src/Writer/XLSX/Manager/WorksheetManager.php
+++ b/src/Writer/XLSX/Manager/WorksheetManager.php
@@ -112,8 +112,19 @@ final readonly class WorksheetManager implements WorksheetManagerInterface
         $numCells = $row->getNumCells();
 
         $rowHeight = $row->height;
-        $hasCustomHeight = ($this->options->DEFAULT_ROW_HEIGHT > 0 || $rowHeight > 0) ? '1' : '0';
-        $rowXML = "<row r=\"{$rowIndexOneBased}\" spans=\"1:{$numCells}\" ".($rowHeight > 0 ? "ht=\"{$rowHeight}\" " : '')."customHeight=\"{$hasCustomHeight}\">";
+
+        // A row only receives an explicit height (plus the customHeight flag) when one is
+        // actually set. Auto-height rows (Row::DEFAULT_HEIGHT) must carry neither `ht`
+        // nor `customHeight`, otherwise strict viewers (e.g. Excel Online, Teams/SharePoint)
+        // treat them as fixed-height instead of auto-fitting their content.
+        // The DEFAULT_ROW_HEIGHT option only affects the sheet's <sheetFormatPr
+        // defaultRowHeight>; it must not mark individual rows as custom-height.
+        // See https://github.com/openspout/openspout/issues/367
+        $rowXML = "<row r=\"{$rowIndexOneBased}\" spans=\"1:{$numCells}\"";
+        if ($rowHeight > 0) {
+            $rowXML .= " ht=\"{$rowHeight}\" customHeight=\"1\"";
+        }
+        $rowXML .= '>';
 
         foreach ($row->cells as $columnIndexZeroBased => $cell) {
             if ($cell instanceof Cell\ImageCell) {

--- a/tests/Writer/XLSX/SheetTest.php
+++ b/tests/Writer/XLSX/SheetTest.php
@@ -128,7 +128,7 @@ final class SheetTest extends TestCase
         self::assertStringContainsString('<sheetFormatPr', $xmlContents, 'No sheetFormatPr tag found in sheet');
         self::assertStringContainsString(' defaultColWidth="10', $xmlContents, 'No default column width found in sheet');
         self::assertStringContainsString(' defaultRowHeight="20', $xmlContents, 'No default row height found in sheet');
-        self::assertStringContainsString(' customHeight="1"', $xmlContents, 'No row height override flag found in row');
+        self::assertStringNotContainsString('customHeight="1"', $xmlContents, 'Default-height row must not be marked as a custom (fixed) height, so auto-height is preserved.');
     }
 
     public function testWritesDefaultRequiredRowHeightIfOmitted(): void

--- a/tests/Writer/XLSX/WriterTest.php
+++ b/tests/Writer/XLSX/WriterTest.php
@@ -539,6 +539,34 @@ final class WriterTest extends TestCase
         self::assertSame('1', $DOMNode->getAttribute('customHeight'), 'Row does not have custom height flag set.');
     }
 
+    /**
+     * Repro of upstream issue #367.
+     *
+     * @see https://github.com/openspout/openspout/issues/367
+     */
+    public function testAddRowWithDefaultHeightShouldKeepAutoHeight(): void
+    {
+        $fileName = 'test_add_row_with_default_height_should_keep_auto_height.xlsx';
+
+        $this->writeToXLSXFile([Row::fromValues(['xlsx--11']), Row::fromValues(['xlsx--12'], 15)], $fileName);
+
+        $xmlReader = $this->getXmlReaderForSheetFromXmlFile($fileName, '1');
+
+        // Row 1: default (auto) height -> neither ht nor customHeight.
+        $xmlReader->readUntilNodeFound('row');
+        $autoRow = $xmlReader->expand();
+        self::assertInstanceOf(DOMElement::class, $autoRow);
+        self::assertSame('', $autoRow->getAttribute('ht'), 'Auto-height row must not declare a fixed height.');
+        self::assertFalse($autoRow->hasAttribute('customHeight'), 'Auto-height row must not set a customHeight flag, so it keeps auto-height behavior in Excel Online.');
+
+        // Row 2: explicit height -> ht + customHeight="1".
+        $xmlReader->next('row');
+        $fixedRow = $xmlReader->expand();
+        self::assertInstanceOf(DOMElement::class, $fixedRow);
+        self::assertSame('15', $fixedRow->getAttribute('ht'), 'Explicit row height does not equal given value.');
+        self::assertSame('1', $fixedRow->getAttribute('customHeight'), 'Explicitly sized row must be flagged as custom height.');
+    }
+
     public function testCloseShouldAddMergeCellTags(): void
     {
         $fileName = 'test_add_row_should_support_column_widths.xlsx';


### PR DESCRIPTION
**Issue:** [#367](https://github.com/openspout/openspout/issues/367) — XLSX files generated with OpenSpout using `Row::DEFAULT_HEIGHT` don't respect auto-height in Excel Online (and MS Teams / SharePoint viewers), where rows can appear hidden or incorrectly sized, while they work fine in Excel Desktop.

**Root cause:** Contrary to the spec, strict viewers infer auto-height from the *absence* of the `customHeight` attribute on a `<row>` element, not from its value. OpenSpout wrote an explicit `customHeight="0"` on default-height rows (and `customHeight="1"` whenever the `DEFAULT_ROW_HEIGHT` option was set, even without an `ht` value). Excel Online treats any present `customHeight` attribute as a manually defined, fixed height, so auto-fit is disabled.

Per ECMA-376 Part 1 ([§18.3.1.73 `row`](https://www.ecma-international.org/publications-and-standards/standards/ecma-376/)), `customHeight` means *"1 if the row height has been manually set"* (default `false`); an auto-fit row is one with `customHeight ≠ true`, and Excel itself encodes it by omitting the attribute entirely. This was verified empirically in Excel Online: an auto row is emitted as `<row r="1" spans="1:1" ht="30.75">` — no `customHeight` — while a fixed row is `<row r="2" spans="1:1" ht="15" customHeight="1">`.

**Not doing:** OpenSpout does not (and should not) compute fitted row heights — that would require reimplementing Excel's text-layout engine. Viewers calculate the fitted `ht` themselves.
