### PR TITLE
docs: fix outdated "edit existing spreadsheet" guide (#408)

### DIFF
--- a/docs/guides/1-add-data-existing-spreadsheet.md
+++ b/docs/guides/1-add-data-existing-spreadsheet.md
@@ -18,9 +18,8 @@ $existingFilePath = 'path/to/orders.xlsx';
 $newFilePath = 'path/to/new-orders.xlsx';
 
 // we need a reader to read the existing file...
-$readerOptions = new Options();
-$readerOptions->SHOULD_FORMAT_DATES = true; // this is to be able to copy dates
-$reader = new Reader($readerOptions);
+// (SHOULD_FORMAT_DATES is needed to be able to copy dates)
+$reader = new Reader(new Options(SHOULD_FORMAT_DATES: true));
 $reader->open($existingFilePath);
 
 // ... and a writer to create the new file

--- a/docs/guides/2-edit-existing-spreadsheet.md
+++ b/docs/guides/2-edit-existing-spreadsheet.md
@@ -62,6 +62,8 @@ foreach ($reader->getSheetIterator() as $sheetIndex => $sheet) {
             // and hand it back through `withCells()`
             $cells = $row->cells;
             $cells[2] = Cell::fromValue('The White Album');
+            // keep the cell indexes in ascending order, as required by the Row constructor
+            ksort($cells);
             $row = $row->withCells($cells);
         }
 

--- a/docs/guides/2-edit-existing-spreadsheet.md
+++ b/docs/guides/2-edit-existing-spreadsheet.md
@@ -35,9 +35,9 @@ $existingFilePath = '/path/to/my-music.ods';
 $newFilePath = '/path/to/my-new-music.ods';
 
 // we need a reader to read the existing file...
-$readerOptions = new Options();
-$readerOptions->SHOULD_FORMAT_DATES = true; // this is to be able to copy dates
-$reader = new Reader($readerOptions);
+// (SHOULD_FORMAT_DATES is needed to be able to copy dates)
+$reader = new Reader(new Options(SHOULD_FORMAT_DATES: true));
+$reader->open($existingFilePath);
 
 // ... and a writer to create the new file
 $writer = new Writer();
@@ -51,12 +51,18 @@ foreach ($reader->getSheetIterator() as $sheetIndex => $sheet) {
     }
 
     foreach ($sheet->getRowIterator() as $rowIndex => $row) {
-        $songTitle = $row->getCellAtIndex(0);
-        $artist = $row->getCellAtIndex(1);
+        // Each row exposes its cells as an array indexed from 0 (column index),
+        // where each value is a `Cell` object whose value can be read via `getValue()`
+        $songTitle = $row->cells[0]->getValue();
+        $artist = $row->cells[1]->getValue();
 
         // Change the album name for "Yellow Submarine"
         if ($songTitle === 'Yellow Submarine') {
-            $row->setCellAtIndex(Cell::fromValue('The White Album'), 2);
+            // Rows are immutable, so build a modified copy of the cells
+            // and hand it back through `withCells()`
+            $cells = $row->cells;
+            $cells[2] = Cell::fromValue('The White Album');
+            $row = $row->withCells($cells);
         }
 
         // skip Bob Marley's songs


### PR DESCRIPTION
## What & Why

Resolves #408. The code samples in the *"Edit an existing spreadsheet"* guide used the v4 APIs `Row::getCellAtIndex()` / `Row::setCellAtIndex()`, which no longer exist in v5 and made the example impossible to run.

While reproducing the failure, I found the guide had **two other latent bugs** that prevented it from running at all:

1. `Reader\ODS\Options` (and `Reader\XLSX\Options`) are now `final readonly` with constructor-promoted properties, so the old `$readerOptions->SHOULD_FORMAT_DATES = true;` pattern throws `Cannot modify readonly property`.
2. The guide never called `$reader->open($existingFilePath)` before iterating, so it would throw `ReaderNotOpenedException`.

The same stale `Options` pattern existed in the *"Add data to an existing spreadsheet"* guide, so it is fixed there too for consistency.
