### PR TITLE
fix: guard against invalid stream resource in CommentsManager::closeWorksheetCommentFiles (#392)

### DIFF
--- a/src/Writer/XLSX/Manager/CommentsManager.php
+++ b/src/Writer/XLSX/Manager/CommentsManager.php
@@ -114,11 +114,17 @@ final class CommentsManager
         $commentFp = $this->commentsFilePointers[$sheetId];
         $drawingFp = $this->drawingFilePointers[$sheetId];
 
-        fwrite($commentFp, self::COMMENTS_XML_FILE_FOOTER);
-        fwrite($drawingFp, self::DRAWINGS_VML_FILE_FOOTER);
+        // guards against TypeError during PHP shutdown: the runtime may free
+        // file handles before destructors run, leaving these pointers invalid
+        if (is_resource($commentFp)) {
+            fwrite($commentFp, self::COMMENTS_XML_FILE_FOOTER);
+            fclose($commentFp);
+        }
 
-        fclose($commentFp);
-        fclose($drawingFp);
+        if (is_resource($drawingFp)) {
+            fwrite($drawingFp, self::DRAWINGS_VML_FILE_FOOTER);
+            fclose($drawingFp);
+        }
 
         unset($this->commentsFilePointers[$sheetId], $this->drawingFilePointers[$sheetId]);
     }

--- a/src/Writer/XLSX/Manager/CommentsManager.php
+++ b/src/Writer/XLSX/Manager/CommentsManager.php
@@ -116,12 +116,12 @@ final class CommentsManager
 
         // guards against TypeError during PHP shutdown: the runtime may free
         // file handles before destructors run, leaving these pointers invalid
-        if (is_resource($commentFp)) {
+        if (\is_resource($commentFp)) {
             fwrite($commentFp, self::COMMENTS_XML_FILE_FOOTER);
             fclose($commentFp);
         }
 
-        if (is_resource($drawingFp)) {
+        if (\is_resource($drawingFp)) {
             fwrite($drawingFp, self::DRAWINGS_VML_FILE_FOOTER);
             fclose($drawingFp);
         }

--- a/tests/Writer/XLSX/Manager/CommentsManagerTest.php
+++ b/tests/Writer/XLSX/Manager/CommentsManagerTest.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace OpenSpout\Writer\XLSX\Manager;
 
+use FilesystemIterator;
 use OpenSpout\Common\Helper\Escaper\XLSX as XLSXEscaper;
 use OpenSpout\Common\Helper\StringHelper;
 use OpenSpout\Writer\Common\Entity\Sheet;
 use OpenSpout\Writer\Common\Entity\Worksheet;
 use OpenSpout\Writer\Common\Manager\SheetManager;
 use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 use ReflectionProperty;
 
 /**
@@ -18,16 +21,13 @@ use ReflectionProperty;
 final class CommentsManagerTest extends TestCase
 {
     /**
-     * Regression test for https://github.com/openspout/openspout/issues/392
-     *
-     * During PHP shutdown (e.g. after a client disconnect during a slow export) the
-     * runtime may free file handles before object destructors run. In that case the
-     * pointers stored in CommentsManager are no longer valid resources by the time
-     * closeWorksheetCommentFiles() is called, and fwrite()/fclose() on them throws a
-     * TypeError. closeWorksheetCommentFiles() must guard against this with is_resource().
+     * @see https://github.com/openspout/openspout/issues/392
      */
     public function testCloseWorksheetCommentFilesShouldNotThrowTypeErrorOnFreedHandles(): void
     {
+        // No value assertions: reaching this point without a TypeError is the goal.
+        self::expectNotToPerformAssertions();
+
         $tempFolder = sys_get_temp_dir().'/openspout-comments-'.uniqid('', true);
         mkdir($tempFolder.'/drawings', 0o700, true);
 
@@ -46,9 +46,6 @@ final class CommentsManagerTest extends TestCase
 
             // Must not throw a TypeError even though the stored handles were freed.
             $commentsManager->closeWorksheetCommentFiles($worksheet);
-
-            // Reaching this point is the expected (fixed) behaviour.
-            self::assertTrue(true);
         } finally {
             $this->removeFolderRecursively($tempFolder);
         }
@@ -71,9 +68,9 @@ final class CommentsManagerTest extends TestCase
             return;
         }
 
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($folderPath, \FilesystemIterator::SKIP_DOTS),
-            \RecursiveIteratorIterator::CHILD_FIRST
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($folderPath, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
         );
 
         foreach ($iterator as $item) {

--- a/tests/Writer/XLSX/Manager/CommentsManagerTest.php
+++ b/tests/Writer/XLSX/Manager/CommentsManagerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSpout\Writer\XLSX\Manager;
+
+use OpenSpout\Common\Helper\Escaper\XLSX as XLSXEscaper;
+use OpenSpout\Common\Helper\StringHelper;
+use OpenSpout\Writer\Common\Entity\Sheet;
+use OpenSpout\Writer\Common\Entity\Worksheet;
+use OpenSpout\Writer\Common\Manager\SheetManager;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+/**
+ * @internal
+ */
+final class CommentsManagerTest extends TestCase
+{
+    /**
+     * Regression test for https://github.com/openspout/openspout/issues/392
+     *
+     * During PHP shutdown (e.g. after a client disconnect during a slow export) the
+     * runtime may free file handles before object destructors run. In that case the
+     * pointers stored in CommentsManager are no longer valid resources by the time
+     * closeWorksheetCommentFiles() is called, and fwrite()/fclose() on them throws a
+     * TypeError. closeWorksheetCommentFiles() must guard against this with is_resource().
+     */
+    public function testCloseWorksheetCommentFilesShouldNotThrowTypeErrorOnFreedHandles(): void
+    {
+        $tempFolder = sys_get_temp_dir().'/openspout-comments-'.uniqid('', true);
+        mkdir($tempFolder.'/drawings', 0o700, true);
+
+        try {
+            $sheetManager = new SheetManager(StringHelper::factory());
+            $sheet = new Sheet(0, 'workbook-'.uniqid(), $sheetManager);
+            $worksheet = new Worksheet($tempFolder.'/worksheets/sheet1.xml', $sheet);
+
+            $commentsManager = new CommentsManager($tempFolder, new XLSXEscaper());
+            $commentsManager->createWorksheetCommentFiles($worksheet);
+
+            // Simulate PHP freeing the file handles during shutdown, so the pointers
+            // stored inside CommentsManager become invalid resources.
+            $this->closeStoredPointers($commentsManager, 'commentsFilePointers');
+            $this->closeStoredPointers($commentsManager, 'drawingFilePointers');
+
+            // Must not throw a TypeError even though the stored handles were freed.
+            $commentsManager->closeWorksheetCommentFiles($worksheet);
+
+            // Reaching this point is the expected (fixed) behaviour.
+            self::assertTrue(true);
+        } finally {
+            $this->removeFolderRecursively($tempFolder);
+        }
+    }
+
+    private function closeStoredPointers(CommentsManager $manager, string $property): void
+    {
+        $reflection = new ReflectionProperty(CommentsManager::class, $property);
+
+        foreach ($reflection->getValue($manager) as $pointer) {
+            if (\is_resource($pointer)) {
+                fclose($pointer);
+            }
+        }
+    }
+
+    private function removeFolderRecursively(string $folderPath): void
+    {
+        if (!is_dir($folderPath)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($folderPath, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($iterator as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+
+        @rmdir($folderPath);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

`CommentsManager::closeWorksheetCommentFiles()` calls `fwrite()` and `fclose()` without first
validating that the stored file pointers are still valid resources. During PHP shutdown (e.g.
after a client disconnect during a slow export), the runtime may free file handles before object
destructors execute, leaving the stored pointers in an invalid state and causing a `TypeError`.

This PR guards both the comments and the drawing file pointers with `is_resource()` before
writing the footers and closing them.

Supersedes https://github.com/openspout/openspout/pull/394

Closes https://github.com/openspout/openspout/issues/392
